### PR TITLE
Add a hacky if ~IsFault check on combining attrs

### DIFF
--- a/arm-v8.5-a/model/aarch_mem.sail
+++ b/arm-v8.5-a/model/aarch_mem.sail
@@ -3686,7 +3686,16 @@ function CombineS1S2Desc (s1desc, s2desc) = {
             result.memattrs = __tc12
         }
     };
-    result.memattrs = MemAttrDefaults(result.memattrs);
+    /* TODO: BS: the original ASL contained just:
+     *
+     * result.memattrs = MemAttrDefaults(result.memattrs);
+     *
+     * but this reads some uninitialized fields, so
+     * I modify this to check if it wasn't a fault first
+     */
+    if ~(IsFault(result)) then {
+        result.memattrs = MemAttrDefaults(result.memattrs);
+    };
     result
 }
 


### PR DESCRIPTION
When combining S1 and S2 memattrs, if the resultant descriptor is a fault,
then don't try combine the memattrs of the faults as this just leads to
reading uninitialized fields and creating unncessary branching in the
symbolic evaluation.