### PR TITLE
Change handling of incomplete pattern match statements

### DIFF
--- a/arm-v9.4-a/coq/arm_extras.v
+++ b/arm-v9.4-a/coq/arm_extras.v
@@ -1,7 +1,7 @@
 (******************************************************************************)
 (*  BSD 3-clause Clear License                                                *)
 (*                                                                            *)
-(*  Copyright (c) 2022                                                        *)
+(*  Copyright (c) 2023                                                        *)
 (*    Arm Limited (or its affiliates),                                        *)
 (*    Thomas Bauereiss,                                                       *)
 (*    Brian Campbell,                                                         *)

--- a/arm-v9.4-a/src/instrs32.sail
+++ b/arm-v9.4-a/src/instrs32.sail
@@ -19816,7 +19816,7 @@ function execute_aarch32_instrs_VABS_Op_A_txt (advsimd, d__arg, elements, esize,
           64 => {
               D_set(d) = FPAbs(D_read(m))
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VABS_Op_A_txt")
         }
     }
 }
@@ -19898,7 +19898,7 @@ function decode_aarch32_instrs_VABS_A2enc_A_txt (cond, D, Vd, size, M, Vm) = {
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VABS_A2enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -19998,7 +19998,7 @@ function decode_aarch32_instrs_VABS_T2enc_A_txt (D, Vd, size, M, Vm) = {
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VABS_T2enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -20168,7 +20168,7 @@ function execute_aarch32_instrs_VADD_f_Op_A_txt (advsimd, d__arg, elements, esiz
           64 => {
               D_set(d) = FPAdd(D_read(n), D_read(m), FPSCR_read())
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VADD_f_Op_A_txt")
         }
     }
 }
@@ -20262,7 +20262,7 @@ function decode_aarch32_instrs_VADD_f_A2enc_A_txt (cond, D, Vn, Vd, size, N, M, 
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VADD_f_A2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -20377,7 +20377,7 @@ function decode_aarch32_instrs_VADD_f_T2enc_A_txt (D, Vn, Vd, size, N, M, Vm) = 
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VADD_f_T2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -22297,7 +22297,7 @@ function execute_aarch32_instrs_VCMP_Op_A_txt (d, esize, m, quiet_nan_exc, with_
           let op64 : bits(64) = if with_zero then FPZero(0b0, 64) else D_read(m);
           nzcv = FPCompare(D_read(d), op64, quiet_nan_exc, FPSCR_read())
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VCMP_Op_A_txt")
     };
     FPSCR_write() = Mk_FPSCR_Type([FPSCR_read__1().bits with 31 .. 28 = nzcv])
 }
@@ -22334,7 +22334,7 @@ function decode_aarch32_instrs_VCMP_A1enc_A_txt (cond, D, Vd, size, E, M, Vm) = 
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VCMP_A1enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -22386,7 +22386,7 @@ function decode_aarch32_instrs_VCMP_A2enc_A_txt (cond, D, Vd, size, E) = {
               esize = 64;
               d = UInt(D @ Vd)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VCMP_A2enc_A_txt")
         };
         let 'esize = esize;
         let 'd = d;
@@ -22440,7 +22440,7 @@ function decode_aarch32_instrs_VCMP_T1enc_A_txt (D, Vd, size, E, M, Vm) = {
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VCMP_T1enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -22490,7 +22490,7 @@ function decode_aarch32_instrs_VCMP_T2enc_A_txt (D, Vd, size, E) = {
               esize = 64;
               d = UInt(D @ Vd)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VCMP_T2enc_A_txt")
         };
         let 'esize = esize;
         let 'd = d;
@@ -22884,7 +22884,7 @@ function decode_aarch32_instrs_VCVT_is_A1enc_A_txt (D, size, Vd, op, Q, M, Vm) =
               esize = 32;
               elements = 2
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VCVT_is_A1enc_A_txt")
         };
         let 'esize = esize;
         let 'elements = elements;
@@ -22934,7 +22934,7 @@ function decode_aarch32_instrs_VCVT_is_T1enc_A_txt (D, size, Vd, op, Q, M, Vm) =
               esize = 32;
               elements = 2
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VCVT_is_T1enc_A_txt")
         };
         let 'esize = esize;
         let 'elements = elements;
@@ -22975,7 +22975,7 @@ function execute_aarch32_instrs_VCVT_iv_Op_A_txt (d, esize, m, rounding, to_inte
           64 => {
               S_set(d) = FPToFixed(D_read(m), 0, is_unsigned, FPSCR_read(), rounding, 32)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VCVT_iv_Op_A_txt")
         }
     } else {
         match esize {
@@ -22989,7 +22989,7 @@ function execute_aarch32_instrs_VCVT_iv_Op_A_txt (d, esize, m, rounding, to_inte
           64 => {
               D_set(d) = FixedToFP(S_read(m), 0, is_unsigned, FPSCR_read(), rounding, 64)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VCVT_iv_Op_A_txt")
         }
     }
 }
@@ -23035,7 +23035,7 @@ function decode_aarch32_instrs_VCVT_iv_A1enc_A_txt (cond, D, opc2, Vd, size, op,
                   esize = 64;
                   m = UInt(M @ Vm)
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_aarch32_instrs_VCVT_iv_A1enc_A_txt")
             }
         } else {
             is_unsigned = op == 0b0;
@@ -23054,7 +23054,7 @@ function decode_aarch32_instrs_VCVT_iv_A1enc_A_txt (cond, D, opc2, Vd, size, op,
                   esize = 64;
                   d = UInt(D @ Vd)
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_aarch32_instrs_VCVT_iv_A1enc_A_txt")
             }
         };
         let 'm = m;
@@ -23118,7 +23118,7 @@ function decode_aarch32_instrs_VCVT_iv_T1enc_A_txt (D, opc2, Vd, size, op, M, Vm
                   esize = 64;
                   m = UInt(M @ Vm)
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_aarch32_instrs_VCVT_iv_T1enc_A_txt")
             }
         } else {
             is_unsigned = op == 0b0;
@@ -23137,7 +23137,7 @@ function decode_aarch32_instrs_VCVT_iv_T1enc_A_txt (D, opc2, Vd, size, op, M, Vm
                   esize = 64;
                   d = UInt(D @ Vd)
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_aarch32_instrs_VCVT_iv_T1enc_A_txt")
             }
         };
         let 'm = m;
@@ -23335,7 +23335,7 @@ function execute_aarch32_instrs_VCVT_xv_Op_A_txt (d, fp_size, frac_bits, size, t
               let result : bits('size) = FPToFixed(D_read(d), frac_bits, is_unsigned, FPSCR_read(), FPRounding_ZERO, size);
               D_set(d) = Extend(result, 64, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VCVT_xv_Op_A_txt")
         }
     } else {
         match fp_size {
@@ -23349,7 +23349,7 @@ function execute_aarch32_instrs_VCVT_xv_Op_A_txt (d, fp_size, frac_bits, size, t
           64 => {
               D_set(d) = FixedToFP(D_read(d)[size - 1 .. 0], frac_bits, is_unsigned, FPSCR_read(), FPRounding_TIEEVEN, 64)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VCVT_xv_Op_A_txt")
         }
     }
 }
@@ -23384,7 +23384,7 @@ function decode_aarch32_instrs_VCVT_xv_A1enc_A_txt (cond, D, op, U, Vd, sf, sx, 
               fp_size = 64;
               d = UInt(D @ Vd)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VCVT_xv_A1enc_A_txt")
         };
         let 'fp_size = fp_size;
         let 'd = d;
@@ -23440,7 +23440,7 @@ function decode_aarch32_instrs_VCVT_xv_T1enc_A_txt (D, op, U, Vd, sf, sx, i, imm
               fp_size = 64;
               d = UInt(D @ Vd)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VCVT_xv_T1enc_A_txt")
         };
         let 'fp_size = fp_size;
         let 'd = d;
@@ -23482,7 +23482,7 @@ function execute_aarch32_instrs_VDIV_Op_A_txt (d, esize, m, n) = {
       64 => {
           D_set(d) = FPDiv(D_read(n), D_read(m), FPSCR_read())
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VDIV_Op_A_txt")
     }
 }
 
@@ -23523,7 +23523,7 @@ function decode_aarch32_instrs_VDIV_A1enc_A_txt (cond, D, Vn, Vd, size, N, M, Vm
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VDIV_A1enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -23583,7 +23583,7 @@ function decode_aarch32_instrs_VDIV_T1enc_A_txt (D, Vn, Vd, size, N, M, Vm) = {
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VDIV_T1enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -23778,7 +23778,7 @@ function decode_aarch32_instrs_VDUP_s_A1enc_A_txt (D, imm4, Vd, Q, M, Vm) = {
               elements = 2;
               index = UInt([imm4[3]])
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VDUP_s_A1enc_A_txt")
         };
         let 'index = index;
         let 'esize = esize;
@@ -23834,7 +23834,7 @@ function decode_aarch32_instrs_VDUP_s_T1enc_A_txt (D, imm4, Vd, Q, M, Vm) = {
               elements = 2;
               index = UInt([imm4[3]])
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VDUP_s_T1enc_A_txt")
         };
         let 'index = index;
         let 'esize = esize;
@@ -24043,7 +24043,7 @@ function execute_aarch32_instrs_VFMA_Op_A_txt (advsimd, d__arg, elements, esize,
                 D_read(n);
               D_set(d) = FPMulAdd(D_read(d), op64, D_read(m), FPSCR_read())
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VFMA_Op_A_txt")
         }
     }
 }
@@ -24142,7 +24142,7 @@ function decode_aarch32_instrs_VFMA_A2enc_A_txt (cond, D, Vn, Vd, size, N, op, M
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VFMA_A2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -24263,7 +24263,7 @@ function decode_aarch32_instrs_VFMA_T2enc_A_txt (D, Vn, Vd, size, N, op, M, Vm) 
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VFMA_T2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -24310,7 +24310,7 @@ function execute_aarch32_instrs_VFNMA_Op_A_txt (d, esize, m, n, op1_neg) = {
           let op64 : bits(64) = if op1_neg then FPNeg(D_read(n)) else D_read(n);
           D_set(d) = FPMulAdd(FPNeg(D_read(d)), op64, D_read(m), FPSCR_read())
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VFNMA_Op_A_txt")
     }
 }
 
@@ -24352,7 +24352,7 @@ function decode_aarch32_instrs_VFNMA_A1enc_A_txt (cond, D, Vn, Vd, size, N, op, 
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VFNMA_A1enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -24414,7 +24414,7 @@ function decode_aarch32_instrs_VFNMA_T1enc_A_txt (D, Vn, Vd, size, N, op, M, Vm)
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VFNMA_T1enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -27027,7 +27027,7 @@ function execute_aarch32_instrs_VLDR_Op_A_txt (add, d, esize, imm32, n) = {
           D_set(d) = if BigEndian(AccessType_ASIMD) then word1 @ word2 else
             word2 @ word1
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VLDR_Op_A_txt")
     }
 }
 
@@ -27058,7 +27058,7 @@ function decode_aarch32_instrs_VLDR_A1enc_A_txt (cond, U, D, Rn, Vd, size, imm8)
           0b11 => {
               d = UInt(D @ Vd)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VLDR_A1enc_A_txt")
         };
         let 'd = d;
         let 'n = UInt(Rn);
@@ -27105,7 +27105,7 @@ function decode_aarch32_instrs_VLDR_T1enc_A_txt (U, D, Rn, Vd, size, imm8) = {
           0b11 => {
               d = UInt(D @ Vd)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VLDR_T1enc_A_txt")
         };
         let 'd = d;
         let 'n = UInt(Rn);
@@ -27385,7 +27385,7 @@ function execute_aarch32_instrs_VMLA_f_Op_A_txt (add, advsimd, d__arg, elements,
                 FPNeg(FPMul(D_read(n), D_read(m), FPSCR_read()));
               D_set(d) = FPAdd(D_read(d), addend64, FPSCR_read())
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VMLA_f_Op_A_txt")
         }
     }
 }
@@ -27484,7 +27484,7 @@ function decode_aarch32_instrs_VMLA_f_A2enc_A_txt (cond, D, Vn, Vd, size, N, op,
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VMLA_f_A2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -27605,7 +27605,7 @@ function decode_aarch32_instrs_VMLA_f_T2enc_A_txt (D, Vn, Vd, size, N, op, M, Vm
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VMLA_f_T2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -28369,7 +28369,7 @@ function decode_aarch32_instrs_VMOV_i_A2enc_A_txt (cond, D, imm4H, Vd, size, imm
               imm64 = VFPExpandImm(imm4H @ imm4L, 64);
               regs = 1
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VMOV_i_A2enc_A_txt")
         };
         let 'regs = regs;
         let 'd = d;
@@ -28580,7 +28580,7 @@ function decode_aarch32_instrs_VMOV_i_T2enc_A_txt (D, imm4H, Vd, size, imm4L) = 
               imm64 = VFPExpandImm(imm4H @ imm4L, 64);
               regs = 1
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VMOV_i_T2enc_A_txt")
         };
         let 'regs = regs;
         let 'd = d;
@@ -29522,7 +29522,7 @@ function execute_aarch32_instrs_VMUL_f_Op_A_txt (advsimd, d__arg, elements, esiz
           64 => {
               D_set(d) = FPMul(D_read(n), D_read(m), FPSCR_read())
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VMUL_f_Op_A_txt")
         }
     }
 }
@@ -29618,7 +29618,7 @@ function decode_aarch32_instrs_VMUL_f_A2enc_A_txt (cond, D, Vn, Vd, size, N, M, 
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VMUL_f_A2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -29735,7 +29735,7 @@ function decode_aarch32_instrs_VMUL_f_T2enc_A_txt (D, Vn, Vd, size, N, M, Vm) = 
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VMUL_f_T2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -30525,7 +30525,7 @@ function execute_aarch32_instrs_VNEG_Op_A_txt (advsimd, d__arg, elements, esize,
           64 => {
               D_set(d) = FPNeg(D_read(m))
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VNEG_Op_A_txt")
         }
     }
 }
@@ -30607,7 +30607,7 @@ function decode_aarch32_instrs_VNEG_A2enc_A_txt (cond, D, Vd, size, M, Vm) = {
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VNEG_A2enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -30707,7 +30707,7 @@ function decode_aarch32_instrs_VNEG_T2enc_A_txt (D, Vd, size, M, Vm) = {
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VNEG_T2enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -30779,7 +30779,7 @@ function execute_aarch32_instrs_VNMLA_Op_A_txt (d, esize, m, n, vtype) = {
             }
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VNMLA_Op_A_txt")
     }
 }
 
@@ -30822,7 +30822,7 @@ function decode_aarch32_instrs_VNMLA_A1enc_A_txt (cond, D, Vn, Vd, size, N, op, 
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VNMLA_A1enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -30885,7 +30885,7 @@ function decode_aarch32_instrs_VNMLA_A2enc_A_txt (cond, D, Vn, Vd, size, N, M, V
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VNMLA_A2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -30947,7 +30947,7 @@ function decode_aarch32_instrs_VNMLA_T1enc_A_txt (D, Vn, Vd, size, N, op, M, Vm)
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VNMLA_T1enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -31008,7 +31008,7 @@ function decode_aarch32_instrs_VNMLA_T2enc_A_txt (D, Vn, Vd, size, N, M, Vm) = {
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VNMLA_T2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -33911,7 +33911,7 @@ function decode_aarch32_instrs_VQRSHRN_A1enc_A_txt (U, D, imm6, Vd, op, M, Vm) =
               elements = 2;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VQRSHRN_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -33972,7 +33972,7 @@ function decode_aarch32_instrs_VQRSHRN_T1enc_A_txt (U, D, imm6, Vd, op, M, Vm) =
               elements = 2;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VQRSHRN_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -34061,7 +34061,7 @@ function decode_aarch32_instrs_VQSHL_i_A1enc_A_txt (U, D, imm6, Vd, op, L, Q, M,
               elements = 1;
               shift_amount = UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VQSHL_i_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -34146,7 +34146,7 @@ function decode_aarch32_instrs_VQSHL_i_T1enc_A_txt (U, D, imm6, Vd, op, L, Q, M,
               elements = 1;
               shift_amount = UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VQSHL_i_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -34342,7 +34342,7 @@ function decode_aarch32_instrs_VQSHRN_A1enc_A_txt (U, D, imm6, Vd, op, M, Vm) = 
               elements = 2;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VQSHRN_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -34403,7 +34403,7 @@ function decode_aarch32_instrs_VQSHRN_T1enc_A_txt (U, D, imm6, Vd, op, M, Vm) = 
               elements = 2;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VQSHRN_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -34642,7 +34642,7 @@ function decode_aarch32_instrs_VRECPE_A1enc_A_txt (D, size, Vd, F, Q, M, Vm) = {
               esize = 32;
               elements = 2
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRECPE_A1enc_A_txt")
         };
         let 'esize = esize;
         let 'elements = elements;
@@ -34691,7 +34691,7 @@ function decode_aarch32_instrs_VRECPE_T1enc_A_txt (D, size, Vd, F, Q, M, Vm) = {
               esize = 32;
               elements = 2
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRECPE_T1enc_A_txt")
         };
         let 'esize = esize;
         let 'elements = elements;
@@ -34873,7 +34873,7 @@ function decode_aarch32_instrs_VREV16_A1enc_A_txt (D, size, Vd, op, Q, M, Vm) = 
           0b00 => {
               container_size = 64
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VREV16_A1enc_A_txt")
         };
         let 'container_size = container_size;
         let 'containers = DIV(64, container_size);
@@ -34920,7 +34920,7 @@ function decode_aarch32_instrs_VREV16_T1enc_A_txt (D, size, Vd, op, Q, M, Vm) = 
           0b00 => {
               container_size = 64
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VREV16_T1enc_A_txt")
         };
         let 'container_size = container_size;
         let 'containers = DIV(64, container_size);
@@ -35180,7 +35180,7 @@ function decode_aarch32_instrs_VRSHR_A1enc_A_txt (U, D, imm6, Vd, L, Q, M, Vm) =
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRSHR_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -35260,7 +35260,7 @@ function decode_aarch32_instrs_VRSHR_T1enc_A_txt (U, D, imm6, Vd, L, Q, M, Vm) =
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRSHR_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -35350,7 +35350,7 @@ function decode_aarch32_instrs_VRSHRN_A1enc_A_txt (D, imm6, Vd, M, Vm) = {
               elements = 2;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRSHRN_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -35404,7 +35404,7 @@ function decode_aarch32_instrs_VRSHRN_T1enc_A_txt (D, imm6, Vd, M, Vm) = {
               elements = 2;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRSHRN_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -35467,7 +35467,7 @@ function decode_aarch32_instrs_VRSQRTE_A1enc_A_txt (D, size, Vd, F, Q, M, Vm) = 
               esize = 32;
               elements = 2
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRSQRTE_A1enc_A_txt")
         };
         let 'esize = esize;
         let 'elements = elements;
@@ -35516,7 +35516,7 @@ function decode_aarch32_instrs_VRSQRTE_T1enc_A_txt (D, size, Vd, F, Q, M, Vm) = 
               esize = 32;
               elements = 2
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRSQRTE_T1enc_A_txt")
         };
         let 'esize = esize;
         let 'elements = elements;
@@ -35703,7 +35703,7 @@ function decode_aarch32_instrs_VRSRA_A1enc_A_txt (U, D, imm6, Vd, L, Q, M, Vm) =
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRSRA_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -35783,7 +35783,7 @@ function decode_aarch32_instrs_VRSRA_T1enc_A_txt (U, D, imm6, Vd, L, Q, M, Vm) =
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRSRA_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -35956,7 +35956,7 @@ function decode_aarch32_instrs_VSHL_i_A1enc_A_txt (D, imm6, Vd, L, Q, M, Vm) = {
               elements = 1;
               shift_amount = UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSHL_i_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36034,7 +36034,7 @@ function decode_aarch32_instrs_VSHL_i_T1enc_A_txt (D, imm6, Vd, L, Q, M, Vm) = {
               elements = 1;
               shift_amount = UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSHL_i_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36121,7 +36121,7 @@ function decode_aarch32_instrs_VSHLL_A1enc_A_txt (U, D, imm6, Vd, M, Vm) = {
               elements = 2;
               shift_amount = UInt(imm6) - 32
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSHLL_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36209,7 +36209,7 @@ function decode_aarch32_instrs_VSHLL_T1enc_A_txt (U, D, imm6, Vd, M, Vm) = {
               elements = 2;
               shift_amount = UInt(imm6) - 32
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSHLL_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36407,7 +36407,7 @@ function decode_aarch32_instrs_VSHR_A1enc_A_txt (U, D, imm6, Vd, L, Q, M, Vm) = 
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSHR_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36487,7 +36487,7 @@ function decode_aarch32_instrs_VSHR_T1enc_A_txt (U, D, imm6, Vd, L, Q, M, Vm) = 
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSHR_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36576,7 +36576,7 @@ function decode_aarch32_instrs_VSHRN_A1enc_A_txt (D, imm6, Vd, M, Vm) = {
               elements = 2;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSHRN_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36630,7 +36630,7 @@ function decode_aarch32_instrs_VSHRN_T1enc_A_txt (D, imm6, Vd, M, Vm) = {
               elements = 2;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSHRN_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36706,7 +36706,7 @@ function decode_aarch32_instrs_VSLI_A1enc_A_txt (D, imm6, Vd, L, Q, M, Vm) = {
               elements = 1;
               shift_amount = UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSLI_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36784,7 +36784,7 @@ function decode_aarch32_instrs_VSLI_T1enc_A_txt (D, imm6, Vd, L, Q, M, Vm) = {
               elements = 1;
               shift_amount = UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSLI_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -36841,7 +36841,7 @@ function execute_aarch32_instrs_VSQRT_Op_A_txt (d, esize, m) = {
       64 => {
           D_set(d) = FPSqrt(D_read(m), FPSCR_read())
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VSQRT_Op_A_txt")
     }
 }
 
@@ -36878,7 +36878,7 @@ function decode_aarch32_instrs_VSQRT_A1enc_A_txt (cond, D, Vd, size, M, Vm) = {
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSQRT_A1enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -36931,7 +36931,7 @@ function decode_aarch32_instrs_VSQRT_T1enc_A_txt (D, Vd, size, M, Vm) = {
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSQRT_T1enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -37004,7 +37004,7 @@ function decode_aarch32_instrs_VSRA_A1enc_A_txt (U, D, imm6, Vd, L, Q, M, Vm) = 
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSRA_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -37084,7 +37084,7 @@ function decode_aarch32_instrs_VSRA_T1enc_A_txt (U, D, imm6, Vd, L, Q, M, Vm) = 
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSRA_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -37181,7 +37181,7 @@ function decode_aarch32_instrs_VSRI_A1enc_A_txt (D, imm6, Vd, L, Q, M, Vm) = {
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSRI_A1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -37259,7 +37259,7 @@ function decode_aarch32_instrs_VSRI_T1enc_A_txt (D, imm6, Vd, L, Q, M, Vm) = {
               elements = 1;
               shift_amount = 64 - UInt(imm6)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSRI_T1enc_A_txt")
         };
         let 'shift_amount = shift_amount;
         let 'esize = esize;
@@ -39358,7 +39358,7 @@ function execute_aarch32_instrs_VSTR_Op_A_txt (add, d, esize, imm32, n) = {
               MemA_set(address + 4, 4) = D_read(d)[63 .. 32]
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VSTR_Op_A_txt")
     }
 }
 
@@ -39389,7 +39389,7 @@ function decode_aarch32_instrs_VSTR_A1enc_A_txt (cond, U, D, Rn, Vd, size, imm8)
           0b11 => {
               d = UInt(D @ Vd)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSTR_A1enc_A_txt")
         };
         let 'd = d;
         let 'n = UInt(Rn);
@@ -39440,7 +39440,7 @@ function decode_aarch32_instrs_VSTR_T1enc_A_txt (U, D, Rn, Vd, size, imm8) = {
           0b11 => {
               d = UInt(D @ Vd)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSTR_T1enc_A_txt")
         };
         let 'd = d;
         let 'n = UInt(Rn);
@@ -39488,7 +39488,7 @@ function execute_aarch32_instrs_VSUB_f_Op_A_txt (advsimd, d__arg, elements, esiz
           64 => {
               D_set(d) = FPSub(D_read(n), D_read(m), FPSCR_read())
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VSUB_f_Op_A_txt")
         }
     }
 }
@@ -39582,7 +39582,7 @@ function decode_aarch32_instrs_VSUB_f_A2enc_A_txt (cond, D, Vn, Vd, size, N, M, 
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSUB_f_A2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -39697,7 +39697,7 @@ function decode_aarch32_instrs_VSUB_f_T2enc_A_txt (D, Vn, Vd, size, N, M, Vm) = 
               n = UInt(N @ Vn);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VSUB_f_T2enc_A_txt")
         };
         let 'n = n;
         let 'm = m;
@@ -41192,7 +41192,7 @@ function execute_aarch32_instrs_MRS_br_Op_AS_txt (SYSm, d, read_spsr) = {
               0b11110 => {
                   R_set(d) = SPSR_hyp_read().bits[31 .. 0]
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_aarch32_instrs_MRS_br_Op_AS_txt")
             }
         } else {
             m : int = undefined;
@@ -41235,7 +41235,7 @@ function execute_aarch32_instrs_MRS_br_Op_AS_txt (SYSm, d, read_spsr) = {
               0b11111 => {
                   R_set(d) = Rmode_read(13, M32_Hyp)
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_aarch32_instrs_MRS_br_Op_AS_txt")
             }
         }
     }
@@ -41336,7 +41336,7 @@ function execute_aarch32_instrs_MSR_br_Op_AS_txt (SYSm, n, write_spsr) = {
               0b11110 => {
                   SPSR_hyp_write() = Mk_SPSR_hyp_Type([SPSR_hyp_read().bits with 31 .. 0 = R_read(n)])
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_aarch32_instrs_MSR_br_Op_AS_txt")
             }
         } else {
             m : int = undefined;
@@ -41379,7 +41379,7 @@ function execute_aarch32_instrs_MSR_br_Op_AS_txt (SYSm, n, write_spsr) = {
               0b11111 => {
                   Rmode_set(13, M32_Hyp) = R_read(n)
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_aarch32_instrs_MSR_br_Op_AS_txt")
             }
         }
     }
@@ -42103,7 +42103,7 @@ function decode_aarch32_instrs_VMSR_A1enc_AS_txt (cond, reg, Rt) = {
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_aarch32_instrs_VMSR_A1enc_AS_txt")
             }
         };
         if t == 15 then {
@@ -42144,7 +42144,7 @@ function decode_aarch32_instrs_VMSR_T1enc_AS_txt (reg, Rt) = {
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_aarch32_instrs_VMSR_T1enc_AS_txt")
             }
         };
         if t == 15 then {
@@ -44665,7 +44665,7 @@ function decode_aarch32_instrs_VCVTA_asimd_A1enc_A_txt (D, size, Vd, RM, op, Q, 
           esize = 32;
           elements = 2
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VCVTA_asimd_A1enc_A_txt")
     };
     let 'esize = esize;
     let 'elements = elements;
@@ -44713,7 +44713,7 @@ function decode_aarch32_instrs_VCVTA_asimd_T1enc_A_txt (D, size, Vd, RM, op, Q, 
           esize = 32;
           elements = 2
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VCVTA_asimd_T1enc_A_txt")
     };
     let 'esize = esize;
     let 'elements = elements;
@@ -44752,7 +44752,7 @@ function execute_aarch32_instrs_VCVTA_vfp_Op_A_txt (d, esize, m, rounding, is_un
       64 => {
           S_set(d) = FPToFixed(D_read(m), 0, is_unsigned, FPSCR_read(), rounding, 32)
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VCVTA_vfp_Op_A_txt")
     }
 }
 
@@ -44780,7 +44780,7 @@ function decode_aarch32_instrs_VCVTA_vfp_A1enc_A_txt (D, RM, Vd, size, op, M, Vm
           esize = 64;
           m = UInt(M @ Vm)
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VCVTA_vfp_A1enc_A_txt")
     };
     let 'm = m;
     let 'esize = esize;
@@ -44826,7 +44826,7 @@ function decode_aarch32_instrs_VCVTA_vfp_T1enc_A_txt (D, RM, Vd, size, op, M, Vm
           esize = 64;
           m = UInt(M @ Vm)
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VCVTA_vfp_T1enc_A_txt")
     };
     let 'm = m;
     let 'esize = esize;
@@ -44889,7 +44889,7 @@ function execute_aarch32_instrs_VMAXNM_Op_A_txt (advsimd, d__arg, elements, esiz
                   D_set(d) = FPMinNum(D_read(n), D_read(m), FPSCR_read())
               }
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch32_instrs_VMAXNM_Op_A_txt")
         }
     }
 }
@@ -44975,7 +44975,7 @@ function decode_aarch32_instrs_VMAXNM_A2enc_A_txt (D, Vn, Vd, size, N, op, M, Vm
           n = UInt(N @ Vn);
           m = UInt(M @ Vm)
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VMAXNM_A2enc_A_txt")
     };
     let 'n = n;
     let 'm = m;
@@ -45084,7 +45084,7 @@ function decode_aarch32_instrs_VMAXNM_T2enc_A_txt (D, Vn, Vd, size, N, op, M, Vm
           n = UInt(N @ Vn);
           m = UInt(M @ Vm)
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VMAXNM_T2enc_A_txt")
     };
     let 'n = n;
     let 'm = m;
@@ -45149,7 +45149,7 @@ function decode_aarch32_instrs_VRINTA_asimd_A1enc_A_txt (D, size, Vd, op, Q, M, 
           esize = 32;
           elements = 2
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VRINTA_asimd_A1enc_A_txt")
     };
     let 'esize = esize;
     let 'elements = elements;
@@ -45199,7 +45199,7 @@ function decode_aarch32_instrs_VRINTA_asimd_T1enc_A_txt (D, size, Vd, op, Q, M, 
           esize = 32;
           elements = 2
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VRINTA_asimd_T1enc_A_txt")
     };
     let 'esize = esize;
     let 'elements = elements;
@@ -45237,7 +45237,7 @@ function execute_aarch32_instrs_VRINTA_vfp_Op_A_txt (d, esize, exact, m, roundin
       64 => {
           D_set(d) = FPRoundInt(D_read(m), FPSCR_read(), rounding, exact)
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VRINTA_vfp_Op_A_txt")
     }
 }
 
@@ -45268,7 +45268,7 @@ function decode_aarch32_instrs_VRINTA_vfp_A1enc_A_txt (D, RM, Vd, size, M, Vm) =
           d = UInt(D @ Vd);
           m = UInt(M @ Vm)
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VRINTA_vfp_A1enc_A_txt")
     };
     let 'm = m;
     let 'esize = esize;
@@ -45317,7 +45317,7 @@ function decode_aarch32_instrs_VRINTA_vfp_T1enc_A_txt (D, RM, Vd, size, M, Vm) =
           d = UInt(D @ Vd);
           m = UInt(M @ Vm)
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VRINTA_vfp_T1enc_A_txt")
     };
     let 'm = m;
     let 'esize = esize;
@@ -45376,7 +45376,7 @@ function decode_aarch32_instrs_VRINTX_asimd_A1enc_A_txt (D, size, Vd, Q, M, Vm) 
           esize = 32;
           elements = 2
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VRINTX_asimd_A1enc_A_txt")
     };
     let 'esize = esize;
     let 'elements = elements;
@@ -45419,7 +45419,7 @@ function decode_aarch32_instrs_VRINTX_asimd_T1enc_A_txt (D, size, Vd, Q, M, Vm) 
           esize = 32;
           elements = 2
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VRINTX_asimd_T1enc_A_txt")
     };
     let 'esize = esize;
     let 'elements = elements;
@@ -45460,7 +45460,7 @@ function execute_aarch32_instrs_VRINTX_vfp_Op_A_txt (d, esize, exact, m) = {
       64 => {
           D_set(d) = FPRoundInt(D_read(m), FPSCR_read(), rounding, exact)
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VRINTX_vfp_Op_A_txt")
     }
 }
 
@@ -45495,7 +45495,7 @@ function decode_aarch32_instrs_VRINTX_vfp_A1enc_A_txt (cond, D, Vd, size, M, Vm)
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRINTX_vfp_A1enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -45546,7 +45546,7 @@ function decode_aarch32_instrs_VRINTX_vfp_T1enc_A_txt (D, Vd, size, M, Vm) = {
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRINTX_vfp_T1enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -45606,7 +45606,7 @@ function decode_aarch32_instrs_VRINTZ_asimd_A1enc_A_txt (D, size, Vd, Q, M, Vm) 
           esize = 32;
           elements = 2
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VRINTZ_asimd_A1enc_A_txt")
     };
     let 'esize = esize;
     let 'elements = elements;
@@ -45649,7 +45649,7 @@ function decode_aarch32_instrs_VRINTZ_asimd_T1enc_A_txt (D, size, Vd, Q, M, Vm) 
           esize = 32;
           elements = 2
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VRINTZ_asimd_T1enc_A_txt")
     };
     let 'esize = esize;
     let 'elements = elements;
@@ -45689,7 +45689,7 @@ function execute_aarch32_instrs_VRINTZ_vfp_Op_A_txt (d, esize, exact, m, roundin
       64 => {
           D_set(d) = FPRoundInt(D_read(m), FPSCR_read(), rounding, exact)
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VRINTZ_vfp_Op_A_txt")
     }
 }
 
@@ -45726,7 +45726,7 @@ function decode_aarch32_instrs_VRINTZ_vfp_A1enc_A_txt (cond, D, Vd, size, op, M,
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRINTZ_vfp_A1enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -45780,7 +45780,7 @@ function decode_aarch32_instrs_VRINTZ_vfp_T1enc_A_txt (D, Vd, size, op, M, Vm) =
               d = UInt(D @ Vd);
               m = UInt(M @ Vm)
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_aarch32_instrs_VRINTZ_vfp_T1enc_A_txt")
         };
         let 'm = m;
         let 'esize = esize;
@@ -45818,7 +45818,7 @@ function execute_aarch32_instrs_VSEL_Op_A_txt (cond, d, esize, m, n) = {
       64 => {
           D_set(d) = if ConditionHolds(cond) then D_read(n) else D_read(m)
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch32_instrs_VSEL_Op_A_txt")
     }
 }
 
@@ -45851,7 +45851,7 @@ function decode_aarch32_instrs_VSEL_A1enc_A_txt (D, cc, Vn, Vd, size, N, M, Vm) 
           n = UInt(N @ Vn);
           m = UInt(M @ Vm)
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VSEL_A1enc_A_txt")
     };
     let 'n = n;
     let 'm = m;
@@ -45906,7 +45906,7 @@ function decode_aarch32_instrs_VSEL_T1enc_A_txt (D, cc, Vn, Vd, size, N, M, Vm) 
           n = UInt(N @ Vn);
           m = UInt(M @ Vm)
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_aarch32_instrs_VSEL_T1enc_A_txt")
     };
     let 'n = n;
     let 'm = m;

--- a/arm-v9.4-a/src/instrs64.sail
+++ b/arm-v9.4-a/src/instrs64.sail
@@ -1645,7 +1645,7 @@ function execute_aarch64_instrs_vector_arithmetic_binary_uniform_logical_and_orr
       LogicalOp_ORR => {
           result = operand1 | operand2
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_vector_arithmetic_binary_uniform_logical_and_orr")
     };
     V_set(d, datasize) = result
 }
@@ -3768,7 +3768,7 @@ function execute_aarch64_instrs_branch_unconditional_register (branch_type, m, n
       BranchType_RET => {
           BTypeNext = 0b00
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_branch_unconditional_register")
     };
     let branch_conditional : bool = false;
     BranchTo(target, branch_type, branch_conditional)
@@ -8042,7 +8042,7 @@ function decode_cpyp_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1, s
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyp_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8099,7 +8099,7 @@ function decode_cpypn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpypn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8156,7 +8156,7 @@ function decode_cpyprn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyprn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8213,7 +8213,7 @@ function decode_cpyprt_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyprt_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8270,7 +8270,7 @@ function decode_cpyprtn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyprtn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8327,7 +8327,7 @@ function decode_cpyprtrn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyprtrn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8384,7 +8384,7 @@ function decode_cpyprtwn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyprtwn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8441,7 +8441,7 @@ function decode_cpypt_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpypt_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8498,7 +8498,7 @@ function decode_cpyptn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyptn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8555,7 +8555,7 @@ function decode_cpyptrn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyptrn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8612,7 +8612,7 @@ function decode_cpyptwn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyptwn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8669,7 +8669,7 @@ function decode_cpypwn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpypwn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8726,7 +8726,7 @@ function decode_cpypwt_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpypwt_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8783,7 +8783,7 @@ function decode_cpypwtn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op1
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpypwtn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8840,7 +8840,7 @@ function decode_cpypwtrn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpypwtrn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -8897,7 +8897,7 @@ function decode_cpypwtwn_aarch64_instrs_memory_mcpymset_cpy (Rd, Rn, op2, Rs, op
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpypwtwn_aarch64_instrs_memory_mcpymset_cpy")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpy(d, n, options_name, s, stage)
@@ -9097,7 +9097,7 @@ function decode_cpyfp_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, op1,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfp_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9154,7 +9154,7 @@ function decode_cpyfpn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, op1
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfpn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9211,7 +9211,7 @@ function decode_cpyfprn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, op
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfprn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9268,7 +9268,7 @@ function decode_cpyfprt_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, op
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfprt_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9325,7 +9325,7 @@ function decode_cpyfprtn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfprtn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9382,7 +9382,7 @@ function decode_cpyfprtrn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfprtrn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9439,7 +9439,7 @@ function decode_cpyfprtwn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfprtwn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9496,7 +9496,7 @@ function decode_cpyfpt_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, op1
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfpt_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9553,7 +9553,7 @@ function decode_cpyfptn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, op
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfptn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9610,7 +9610,7 @@ function decode_cpyfptrn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfptrn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9667,7 +9667,7 @@ function decode_cpyfptwn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfptwn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9724,7 +9724,7 @@ function decode_cpyfpwn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, op
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfpwn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9781,7 +9781,7 @@ function decode_cpyfpwt_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, op
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfpwt_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9838,7 +9838,7 @@ function decode_cpyfpwtn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfpwtn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9895,7 +9895,7 @@ function decode_cpyfpwtrn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfpwtrn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -9952,7 +9952,7 @@ function decode_cpyfpwtwn_aarch64_instrs_memory_mcpymset_cpyf (Rd, Rn, op2, Rs, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_cpyfpwtwn_aarch64_instrs_memory_mcpymset_cpyf")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_cpyf(d, n, options_name, s, stage)
@@ -11275,7 +11275,7 @@ function execute_aarch64_instrs_vector_arithmetic_binary_uniform_cmp_fp16_sisd (
           CompareOp_GT => {
               test_passed = FPCompareGT(element1, element2, fpcr)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch64_instrs_vector_arithmetic_binary_uniform_cmp_fp16_sisd")
         };
         result = Elem_set(result, e, esize, if test_passed then Ones(esize) else
           Zeros(esize))
@@ -16867,7 +16867,7 @@ function execute_aarch64_instrs_float_convert_fix (d, fltsize, fracbits, intsize
           fltval = Elem_set(fltval, 0, fltsize, FixedToFP(intval, fracbits, is_unsigned, fpcr, rounding, fltsize));
           V_set(d, fsize) = fltval
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_float_convert_fix")
     }
 }
 
@@ -22871,7 +22871,7 @@ function decode_ld1_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb (Rt, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld1_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -22941,7 +22941,7 @@ function decode_ld1_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc (R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld1_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23011,7 +23011,7 @@ function decode_ld1r_advsimd_aarch64_instrs_memory_vector_single_no_wb (Rt, Rn, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld1r_advsimd_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23081,7 +23081,7 @@ function decode_ld1r_advsimd_aarch64_instrs_memory_vector_single_post_inc (Rt, R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld1r_advsimd_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23151,7 +23151,7 @@ function decode_ld2_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb (Rt, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld2_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23221,7 +23221,7 @@ function decode_ld2_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc (R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld2_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23291,7 +23291,7 @@ function decode_ld2r_advsimd_aarch64_instrs_memory_vector_single_no_wb (Rt, Rn, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld2r_advsimd_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23361,7 +23361,7 @@ function decode_ld2r_advsimd_aarch64_instrs_memory_vector_single_post_inc (Rt, R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld2r_advsimd_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23431,7 +23431,7 @@ function decode_ld3_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb (Rt, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld3_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23501,7 +23501,7 @@ function decode_ld3_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc (R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld3_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23571,7 +23571,7 @@ function decode_ld3r_advsimd_aarch64_instrs_memory_vector_single_no_wb (Rt, Rn, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld3r_advsimd_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23641,7 +23641,7 @@ function decode_ld3r_advsimd_aarch64_instrs_memory_vector_single_post_inc (Rt, R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld3r_advsimd_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23711,7 +23711,7 @@ function decode_ld4_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb (Rt, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld4_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23781,7 +23781,7 @@ function decode_ld4_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc (R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld4_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23851,7 +23851,7 @@ function decode_ld4r_advsimd_aarch64_instrs_memory_vector_single_no_wb (Rt, Rn, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld4r_advsimd_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23921,7 +23921,7 @@ function decode_ld4r_advsimd_aarch64_instrs_memory_vector_single_post_inc (Rt, R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ld4r_advsimd_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -23991,7 +23991,7 @@ function decode_st1_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb (Rt, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_st1_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -24061,7 +24061,7 @@ function decode_st1_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc (R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_st1_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -24131,7 +24131,7 @@ function decode_st2_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb (Rt, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_st2_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -24201,7 +24201,7 @@ function decode_st2_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc (R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_st2_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -24271,7 +24271,7 @@ function decode_st3_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb (Rt, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_st3_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -24341,7 +24341,7 @@ function decode_st3_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc (R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_st3_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -24411,7 +24411,7 @@ function decode_st4_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb (Rt, 
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_st4_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb")
     };
     let 'scale = scale;
     let 'index = index;
@@ -24481,7 +24481,7 @@ function decode_st4_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc (R
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_st4_advsimd_sngl_aarch64_instrs_memory_vector_single_post_inc")
     };
     let 'scale = scale;
     let 'index = index;
@@ -27218,7 +27218,7 @@ function decode_ldap1_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb_ord
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ldap1_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb_ordered")
     };
     let 'scale = scale;
     let 'index = index;
@@ -27287,7 +27287,7 @@ function decode_stl1_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb_orde
               scale = 3
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_stl1_advsimd_sngl_aarch64_instrs_memory_vector_single_no_wb_ordered")
     };
     let 'scale = scale;
     let 'index = index;
@@ -27406,7 +27406,7 @@ function decode_ldapr_aarch64_instrs_memory_ordered_rcpc_writeback (Rt, Rn, size
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapr_aarch64_instrs_memory_ordered_rcpc_writeback")
         }
     };
     execute_aarch64_instrs_memory_ordered_rcpc(datasize, n, offset, regsize, t, tagchecked, wb_unknown, wback)
@@ -27599,7 +27599,7 @@ function decode_ldapur_gen_aarch64_instrs_memory_single_general_immediate_signed
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapur_gen_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -27618,7 +27618,7 @@ function decode_ldapur_gen_aarch64_instrs_memory_single_general_immediate_signed
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapur_gen_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl(datasize, memop, n, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -27684,7 +27684,7 @@ function decode_ldapurb_aarch64_instrs_memory_single_general_immediate_signed_of
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapurb_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -27703,7 +27703,7 @@ function decode_ldapurb_aarch64_instrs_memory_single_general_immediate_signed_of
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapurb_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl(datasize, memop, n, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -27769,7 +27769,7 @@ function decode_ldapurh_aarch64_instrs_memory_single_general_immediate_signed_of
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapurh_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -27788,7 +27788,7 @@ function decode_ldapurh_aarch64_instrs_memory_single_general_immediate_signed_of
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapurh_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl(datasize, memop, n, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -27854,7 +27854,7 @@ function decode_ldapursb_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapursb_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -27873,7 +27873,7 @@ function decode_ldapursb_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapursb_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl(datasize, memop, n, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -27939,7 +27939,7 @@ function decode_ldapursh_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapursh_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -27958,7 +27958,7 @@ function decode_ldapursh_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapursh_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl(datasize, memop, n, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -28024,7 +28024,7 @@ function decode_ldapursw_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapursw_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -28043,7 +28043,7 @@ function decode_ldapursw_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldapursw_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl(datasize, memop, n, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -28109,7 +28109,7 @@ function decode_stlur_gen_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlur_gen_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -28128,7 +28128,7 @@ function decode_stlur_gen_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlur_gen_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl(datasize, memop, n, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -28194,7 +28194,7 @@ function decode_stlurb_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlurb_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -28213,7 +28213,7 @@ function decode_stlurb_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlurb_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl(datasize, memop, n, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -28279,7 +28279,7 @@ function decode_stlurh_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlurh_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -28298,7 +28298,7 @@ function decode_stlurh_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlurh_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_lda_stl(datasize, memop, n, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -28343,7 +28343,7 @@ function execute_aarch64_instrs_memory_single_simdfp_immediate_signed_offset_ord
           assert(constraint('datasize in {8, 16, 32, 64, 128}));
           V_set(t, datasize) = data
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_single_simdfp_immediate_signed_offset_ordered")
     };
     if wback then {
         if postindex then {
@@ -28466,7 +28466,7 @@ function execute_aarch64_instrs_memory_ordered (datasize, limitedordered, memop,
           assert(constraint(('datasize >= 0 & 'regsize >= 'datasize)));
           X_set(t, regsize) = ZeroExtend(data, regsize)
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_ordered")
     };
     if SPESampleInFlight then {
         let ar : bits(1) = 0b1;
@@ -28857,7 +28857,7 @@ function decode_stlr_aarch64_instrs_memory_ordered_writeback (Rt, Rn, size) = {
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlr_aarch64_instrs_memory_ordered_writeback")
         }
     };
     execute_aarch64_instrs_memory_ordered(datasize, limitedordered, memop, n, offset, regsize, rt_unknown, t, tagchecked, wback)
@@ -29011,7 +29011,7 @@ function execute_aarch64_instrs_memory_exclusive_pair (acqrel, datasize, elsize,
               X_set(t, regsize) = ZeroExtend(data, regsize)
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_exclusive_pair")
     };
     if SPESampleInFlight then {
         let ar : bits(1) = if acqrel then 0b1 else 0b0;
@@ -29052,7 +29052,7 @@ function decode_ldaxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldaxp_aarch64_instrs_memory_exclusive_pair")
         }
     };
     if memop == MemOp_STORE then {
@@ -29069,7 +29069,7 @@ function decode_ldaxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs,
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldaxp_aarch64_instrs_memory_exclusive_pair")
             }
         };
         if s == n & n != 31 then {
@@ -29085,7 +29085,7 @@ function decode_ldaxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs,
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldaxp_aarch64_instrs_memory_exclusive_pair")
             }
         };
         ()
@@ -29138,7 +29138,7 @@ function decode_ldxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldxp_aarch64_instrs_memory_exclusive_pair")
         }
     };
     if memop == MemOp_STORE then {
@@ -29155,7 +29155,7 @@ function decode_ldxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldxp_aarch64_instrs_memory_exclusive_pair")
             }
         };
         if s == n & n != 31 then {
@@ -29171,7 +29171,7 @@ function decode_ldxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldxp_aarch64_instrs_memory_exclusive_pair")
             }
         };
         ()
@@ -29224,7 +29224,7 @@ function decode_stlxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlxp_aarch64_instrs_memory_exclusive_pair")
         }
     };
     if memop == MemOp_STORE then {
@@ -29241,7 +29241,7 @@ function decode_stlxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs,
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stlxp_aarch64_instrs_memory_exclusive_pair")
             }
         };
         if s == n & n != 31 then {
@@ -29257,7 +29257,7 @@ function decode_stlxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs,
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stlxp_aarch64_instrs_memory_exclusive_pair")
             }
         };
         ()
@@ -29306,7 +29306,7 @@ function decode_stxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stxp_aarch64_instrs_memory_exclusive_pair")
         }
     };
     if memop == MemOp_STORE then {
@@ -29323,7 +29323,7 @@ function decode_stxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stxp_aarch64_instrs_memory_exclusive_pair")
             }
         };
         if s == n & n != 31 then {
@@ -29339,7 +29339,7 @@ function decode_stxp_aarch64_instrs_memory_exclusive_pair (Rt, Rn, Rt2, o0, Rs, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stxp_aarch64_instrs_memory_exclusive_pair")
             }
         };
         ()
@@ -29431,7 +29431,7 @@ function execute_aarch64_instrs_memory_exclusive_single (acqrel, datasize, elsiz
               X_set(t, regsize) = ZeroExtend(data, regsize)
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_exclusive_single")
     };
     if SPESampleInFlight then {
         let ar : bits(1) = if acqrel then 0b1 else 0b0;
@@ -29472,7 +29472,7 @@ function decode_ldaxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldaxr_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -29489,7 +29489,7 @@ function decode_ldaxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldaxr_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -29505,7 +29505,7 @@ function decode_ldaxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldaxr_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -29558,7 +29558,7 @@ function decode_ldaxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldaxrb_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -29575,7 +29575,7 @@ function decode_ldaxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldaxrb_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -29591,7 +29591,7 @@ function decode_ldaxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldaxrb_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -29644,7 +29644,7 @@ function decode_ldaxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldaxrh_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -29661,7 +29661,7 @@ function decode_ldaxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldaxrh_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -29677,7 +29677,7 @@ function decode_ldaxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldaxrh_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -29730,7 +29730,7 @@ function decode_ldxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, Rs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldxr_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -29747,7 +29747,7 @@ function decode_ldxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, Rs
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldxr_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -29763,7 +29763,7 @@ function decode_ldxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, Rs
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldxr_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -29816,7 +29816,7 @@ function decode_ldxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldxrb_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -29833,7 +29833,7 @@ function decode_ldxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldxrb_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -29849,7 +29849,7 @@ function decode_ldxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldxrb_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -29902,7 +29902,7 @@ function decode_ldxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldxrh_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -29919,7 +29919,7 @@ function decode_ldxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldxrh_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -29935,7 +29935,7 @@ function decode_ldxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_ldxrh_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -29988,7 +29988,7 @@ function decode_stlxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlxr_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -30005,7 +30005,7 @@ function decode_stlxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stlxr_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -30021,7 +30021,7 @@ function decode_stlxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stlxr_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -30074,7 +30074,7 @@ function decode_stlxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlxrb_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -30091,7 +30091,7 @@ function decode_stlxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stlxrb_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -30107,7 +30107,7 @@ function decode_stlxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stlxrb_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -30160,7 +30160,7 @@ function decode_stlxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stlxrh_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -30177,7 +30177,7 @@ function decode_stlxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stlxrh_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -30193,7 +30193,7 @@ function decode_stlxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, 
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stlxrh_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -30246,7 +30246,7 @@ function decode_stxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, Rs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stxr_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -30263,7 +30263,7 @@ function decode_stxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, Rs
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stxr_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -30279,7 +30279,7 @@ function decode_stxr_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, Rs
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stxr_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -30332,7 +30332,7 @@ function decode_stxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stxrb_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -30349,7 +30349,7 @@ function decode_stxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stxrb_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -30365,7 +30365,7 @@ function decode_stxrb_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stxrb_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -30418,7 +30418,7 @@ function decode_stxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stxrh_aarch64_instrs_memory_exclusive_single")
         }
     };
     if memop == MemOp_STORE then {
@@ -30435,7 +30435,7 @@ function decode_stxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stxrh_aarch64_instrs_memory_exclusive_single")
             }
         };
         if s == n & n != 31 then {
@@ -30451,7 +30451,7 @@ function decode_stxrh_aarch64_instrs_memory_exclusive_single (Rt, Rn, Rt2, o0, R
               Constraint_NOP => {
                   EndOfInstruction()
               },
-              _ => ()
+              _ => PatternMatchFailure("decode_stxrh_aarch64_instrs_memory_exclusive_single")
             }
         };
         ()
@@ -30528,7 +30528,7 @@ function decode_ldclrp_aarch64_instrs_memory_atomicops_ld_128_ldclrp (Rt, Rn, op
       0b011 => {
           op = MemAtomicOp_ORR
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ldclrp_aarch64_instrs_memory_atomicops_ld_128_ldclrp")
     };
     let acquire : bool = A == 0b1;
     let release : bool = R == 0b1;
@@ -30713,7 +30713,7 @@ function execute_aarch64_instrs_memory_ordered_pair_ldiapp (datasize, memop, n, 
           X_set(t, datasize) = data1;
           X_set(t2, datasize) = data2
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_ordered_pair_ldiapp")
     };
     if wback then {
         if wb_unknown then {
@@ -30772,7 +30772,7 @@ function decode_ldiapp_aarch64_instrs_memory_ordered_pair_ldiapp (Rt, Rn, opc2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldiapp_aarch64_instrs_memory_ordered_pair_ldiapp")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -30791,7 +30791,7 @@ function decode_ldiapp_aarch64_instrs_memory_ordered_pair_ldiapp (Rt, Rn, opc2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldiapp_aarch64_instrs_memory_ordered_pair_ldiapp")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -30807,7 +30807,7 @@ function decode_ldiapp_aarch64_instrs_memory_ordered_pair_ldiapp (Rt, Rn, opc2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldiapp_aarch64_instrs_memory_ordered_pair_ldiapp")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -30882,7 +30882,7 @@ function execute_aarch64_instrs_memory_pair_general_no_alloc (datasize, memop, n
           X_set(t, datasize) = data1;
           X_set(t2, datasize) = data2
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_pair_general_no_alloc")
     };
     if wback then {
         if postindex then {
@@ -30931,7 +30931,7 @@ function decode_ldnp_gen_aarch64_instrs_memory_pair_general_no_alloc (Rt, Rn, Rt
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldnp_gen_aarch64_instrs_memory_pair_general_no_alloc")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -30980,7 +30980,7 @@ function decode_stnp_gen_aarch64_instrs_memory_pair_general_no_alloc (Rt, Rn, Rt
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stnp_gen_aarch64_instrs_memory_pair_general_no_alloc")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -31037,7 +31037,7 @@ function execute_aarch64_instrs_memory_pair_simdfp_no_alloc (datasize, memop, n,
           V_set(t, datasize) = data1;
           V_set(t2, datasize) = data2
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_pair_simdfp_no_alloc")
     };
     if wback then {
         if postindex then {
@@ -31086,7 +31086,7 @@ function decode_ldnp_fpsimd_aarch64_instrs_memory_pair_simdfp_no_alloc (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldnp_fpsimd_aarch64_instrs_memory_pair_simdfp_no_alloc")
         }
     };
     assert(constraint('datasize in {32, 64, 128, 256}));
@@ -31135,7 +31135,7 @@ function decode_stnp_fpsimd_aarch64_instrs_memory_pair_simdfp_no_alloc (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stnp_fpsimd_aarch64_instrs_memory_pair_simdfp_no_alloc")
         }
     };
     assert(constraint('datasize in {32, 64, 128, 256}));
@@ -31192,7 +31192,7 @@ function execute_aarch64_instrs_memory_pair_simdfp_post_idx (datasize, memop, n,
           V_set(t, datasize) = data1;
           V_set(t2, datasize) = data2
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_pair_simdfp_post_idx")
     };
     if wback then {
         if postindex then {
@@ -31241,7 +31241,7 @@ function decode_ldp_fpsimd_aarch64_instrs_memory_pair_simdfp_post_idx (Rt, Rn, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_fpsimd_aarch64_instrs_memory_pair_simdfp_post_idx")
         }
     };
     assert(constraint('datasize in {32, 64, 128, 256}));
@@ -31290,7 +31290,7 @@ function decode_ldp_fpsimd_aarch64_instrs_memory_pair_simdfp_pre_idx (Rt, Rn, Rt
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_fpsimd_aarch64_instrs_memory_pair_simdfp_pre_idx")
         }
     };
     assert(constraint('datasize in {32, 64, 128, 256}));
@@ -31339,7 +31339,7 @@ function decode_ldp_fpsimd_aarch64_instrs_memory_pair_simdfp_offset (Rt, Rn, Rt2
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_fpsimd_aarch64_instrs_memory_pair_simdfp_offset")
         }
     };
     assert(constraint('datasize in {32, 64, 128, 256}));
@@ -31388,7 +31388,7 @@ function decode_stp_fpsimd_aarch64_instrs_memory_pair_simdfp_post_idx (Rt, Rn, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_fpsimd_aarch64_instrs_memory_pair_simdfp_post_idx")
         }
     };
     assert(constraint('datasize in {32, 64, 128, 256}));
@@ -31437,7 +31437,7 @@ function decode_stp_fpsimd_aarch64_instrs_memory_pair_simdfp_pre_idx (Rt, Rn, Rt
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_fpsimd_aarch64_instrs_memory_pair_simdfp_pre_idx")
         }
     };
     assert(constraint('datasize in {32, 64, 128, 256}));
@@ -31486,7 +31486,7 @@ function decode_stp_fpsimd_aarch64_instrs_memory_pair_simdfp_offset (Rt, Rn, Rt2
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_fpsimd_aarch64_instrs_memory_pair_simdfp_offset")
         }
     };
     assert(constraint('datasize in {32, 64, 128, 256}));
@@ -31577,7 +31577,7 @@ function execute_aarch64_instrs_memory_pair_general_post_idx (datasize, memop, n
               X_set(t2, datasize) = data2
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_pair_general_post_idx")
     };
     if wback then {
         if wb_unknown then {
@@ -31633,7 +31633,7 @@ function decode_ldp_gen_aarch64_instrs_memory_pair_general_post_idx (Rt, Rn, Rt2
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_gen_aarch64_instrs_memory_pair_general_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -31652,7 +31652,7 @@ function decode_ldp_gen_aarch64_instrs_memory_pair_general_post_idx (Rt, Rn, Rt2
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_gen_aarch64_instrs_memory_pair_general_post_idx")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -31668,7 +31668,7 @@ function decode_ldp_gen_aarch64_instrs_memory_pair_general_post_idx (Rt, Rn, Rt2
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_gen_aarch64_instrs_memory_pair_general_post_idx")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -31722,7 +31722,7 @@ function decode_ldp_gen_aarch64_instrs_memory_pair_general_pre_idx (Rt, Rn, Rt2,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_gen_aarch64_instrs_memory_pair_general_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -31741,7 +31741,7 @@ function decode_ldp_gen_aarch64_instrs_memory_pair_general_pre_idx (Rt, Rn, Rt2,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_gen_aarch64_instrs_memory_pair_general_pre_idx")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -31757,7 +31757,7 @@ function decode_ldp_gen_aarch64_instrs_memory_pair_general_pre_idx (Rt, Rn, Rt2,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_gen_aarch64_instrs_memory_pair_general_pre_idx")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -31811,7 +31811,7 @@ function decode_ldp_gen_aarch64_instrs_memory_pair_general_offset (Rt, Rn, Rt2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_gen_aarch64_instrs_memory_pair_general_offset")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -31830,7 +31830,7 @@ function decode_ldp_gen_aarch64_instrs_memory_pair_general_offset (Rt, Rn, Rt2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_gen_aarch64_instrs_memory_pair_general_offset")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -31846,7 +31846,7 @@ function decode_ldp_gen_aarch64_instrs_memory_pair_general_offset (Rt, Rn, Rt2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldp_gen_aarch64_instrs_memory_pair_general_offset")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -31900,7 +31900,7 @@ function decode_ldpsw_aarch64_instrs_memory_pair_general_post_idx (Rt, Rn, Rt2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldpsw_aarch64_instrs_memory_pair_general_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -31919,7 +31919,7 @@ function decode_ldpsw_aarch64_instrs_memory_pair_general_post_idx (Rt, Rn, Rt2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldpsw_aarch64_instrs_memory_pair_general_post_idx")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -31935,7 +31935,7 @@ function decode_ldpsw_aarch64_instrs_memory_pair_general_post_idx (Rt, Rn, Rt2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldpsw_aarch64_instrs_memory_pair_general_post_idx")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -31989,7 +31989,7 @@ function decode_ldpsw_aarch64_instrs_memory_pair_general_pre_idx (Rt, Rn, Rt2, i
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldpsw_aarch64_instrs_memory_pair_general_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -32008,7 +32008,7 @@ function decode_ldpsw_aarch64_instrs_memory_pair_general_pre_idx (Rt, Rn, Rt2, i
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldpsw_aarch64_instrs_memory_pair_general_pre_idx")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -32024,7 +32024,7 @@ function decode_ldpsw_aarch64_instrs_memory_pair_general_pre_idx (Rt, Rn, Rt2, i
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldpsw_aarch64_instrs_memory_pair_general_pre_idx")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -32078,7 +32078,7 @@ function decode_ldpsw_aarch64_instrs_memory_pair_general_offset (Rt, Rn, Rt2, im
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldpsw_aarch64_instrs_memory_pair_general_offset")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -32097,7 +32097,7 @@ function decode_ldpsw_aarch64_instrs_memory_pair_general_offset (Rt, Rn, Rt2, im
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldpsw_aarch64_instrs_memory_pair_general_offset")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -32113,7 +32113,7 @@ function decode_ldpsw_aarch64_instrs_memory_pair_general_offset (Rt, Rn, Rt2, im
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldpsw_aarch64_instrs_memory_pair_general_offset")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -32167,7 +32167,7 @@ function decode_stp_gen_aarch64_instrs_memory_pair_general_post_idx (Rt, Rn, Rt2
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_gen_aarch64_instrs_memory_pair_general_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -32186,7 +32186,7 @@ function decode_stp_gen_aarch64_instrs_memory_pair_general_post_idx (Rt, Rn, Rt2
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_gen_aarch64_instrs_memory_pair_general_post_idx")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -32202,7 +32202,7 @@ function decode_stp_gen_aarch64_instrs_memory_pair_general_post_idx (Rt, Rn, Rt2
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_gen_aarch64_instrs_memory_pair_general_post_idx")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -32256,7 +32256,7 @@ function decode_stp_gen_aarch64_instrs_memory_pair_general_pre_idx (Rt, Rn, Rt2,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_gen_aarch64_instrs_memory_pair_general_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -32275,7 +32275,7 @@ function decode_stp_gen_aarch64_instrs_memory_pair_general_pre_idx (Rt, Rn, Rt2,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_gen_aarch64_instrs_memory_pair_general_pre_idx")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -32291,7 +32291,7 @@ function decode_stp_gen_aarch64_instrs_memory_pair_general_pre_idx (Rt, Rn, Rt2,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_gen_aarch64_instrs_memory_pair_general_pre_idx")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -32345,7 +32345,7 @@ function decode_stp_gen_aarch64_instrs_memory_pair_general_offset (Rt, Rn, Rt2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_gen_aarch64_instrs_memory_pair_general_offset")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -32364,7 +32364,7 @@ function decode_stp_gen_aarch64_instrs_memory_pair_general_offset (Rt, Rn, Rt2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_gen_aarch64_instrs_memory_pair_general_offset")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -32380,7 +32380,7 @@ function decode_stp_gen_aarch64_instrs_memory_pair_general_offset (Rt, Rn, Rt2, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stp_gen_aarch64_instrs_memory_pair_general_offset")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -32427,7 +32427,7 @@ function execute_aarch64_instrs_memory_single_simdfp_immediate_signed_post_idx (
           assert(constraint('datasize in {8, 16, 32, 64, 128}));
           V_set(t, datasize) = data
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_single_simdfp_immediate_signed_post_idx")
     };
     if wback then {
         if postindex then {
@@ -32646,7 +32646,7 @@ function execute_aarch64_instrs_memory_literal_general (memop, nontemporal, offs
       MemOp_PREFETCH => {
           Prefetch(address, t[4 .. 0])
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_literal_general")
     };
     if SPESampleInFlight then {
         SPESampleGeneralPurposeLoadStore()
@@ -32934,7 +32934,7 @@ function decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_signe
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -32953,7 +32953,7 @@ function decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_signe
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33020,7 +33020,7 @@ function decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_signe
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33039,7 +33039,7 @@ function decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_signe
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33106,7 +33106,7 @@ function decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_unsig
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33125,7 +33125,7 @@ function decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_unsig
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldr_imm_gen_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33192,7 +33192,7 @@ function decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33211,7 +33211,7 @@ function decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33278,7 +33278,7 @@ function decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33297,7 +33297,7 @@ function decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33364,7 +33364,7 @@ function decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33383,7 +33383,7 @@ function decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrb_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33450,7 +33450,7 @@ function decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33469,7 +33469,7 @@ function decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33536,7 +33536,7 @@ function decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33555,7 +33555,7 @@ function decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33622,7 +33622,7 @@ function decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33641,7 +33641,7 @@ function decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrh_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33708,7 +33708,7 @@ function decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33727,7 +33727,7 @@ function decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33794,7 +33794,7 @@ function decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33813,7 +33813,7 @@ function decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33880,7 +33880,7 @@ function decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_unsigne
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33899,7 +33899,7 @@ function decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_unsigne
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsb_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -33966,7 +33966,7 @@ function decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -33985,7 +33985,7 @@ function decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34052,7 +34052,7 @@ function decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34071,7 +34071,7 @@ function decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34138,7 +34138,7 @@ function decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_unsigne
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34157,7 +34157,7 @@ function decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_unsigne
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsh_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34224,7 +34224,7 @@ function decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34243,7 +34243,7 @@ function decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34310,7 +34310,7 @@ function decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34329,7 +34329,7 @@ function decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_signed_
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34396,7 +34396,7 @@ function decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_unsigne
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34415,7 +34415,7 @@ function decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_unsigne
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsw_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34482,7 +34482,7 @@ function decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_signe
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34501,7 +34501,7 @@ function decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_signe
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34568,7 +34568,7 @@ function decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_signe
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34587,7 +34587,7 @@ function decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_signe
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34654,7 +34654,7 @@ function decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_unsig
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34673,7 +34673,7 @@ function decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_unsig
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_str_imm_gen_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34740,7 +34740,7 @@ function decode_strb_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strb_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34759,7 +34759,7 @@ function decode_strb_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strb_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34826,7 +34826,7 @@ function decode_strb_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strb_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34845,7 +34845,7 @@ function decode_strb_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strb_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34912,7 +34912,7 @@ function decode_strb_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strb_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -34931,7 +34931,7 @@ function decode_strb_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strb_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -34998,7 +34998,7 @@ function decode_strh_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strh_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35017,7 +35017,7 @@ function decode_strh_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strh_imm_aarch64_instrs_memory_single_general_immediate_signed_post_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -35084,7 +35084,7 @@ function decode_strh_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strh_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35103,7 +35103,7 @@ function decode_strh_imm_aarch64_instrs_memory_single_general_immediate_signed_p
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strh_imm_aarch64_instrs_memory_single_general_immediate_signed_pre_idx")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -35170,7 +35170,7 @@ function decode_strh_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strh_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35189,7 +35189,7 @@ function decode_strh_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strh_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_post_idx(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -35333,7 +35333,7 @@ function decode_ldr_reg_gen_aarch64_instrs_memory_single_general_register (Rt, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldr_reg_gen_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35352,7 +35352,7 @@ function decode_ldr_reg_gen_aarch64_instrs_memory_single_general_register (Rt, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldr_reg_gen_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -35430,7 +35430,7 @@ function decode_ldrb_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrb_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35449,7 +35449,7 @@ function decode_ldrb_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrb_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -35527,7 +35527,7 @@ function decode_ldrh_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrh_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35546,7 +35546,7 @@ function decode_ldrh_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrh_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -35624,7 +35624,7 @@ function decode_ldrsb_reg_aarch64_instrs_memory_single_general_register (Rt, Rn,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsb_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35643,7 +35643,7 @@ function decode_ldrsb_reg_aarch64_instrs_memory_single_general_register (Rt, Rn,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsb_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -35721,7 +35721,7 @@ function decode_ldrsh_reg_aarch64_instrs_memory_single_general_register (Rt, Rn,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsh_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35740,7 +35740,7 @@ function decode_ldrsh_reg_aarch64_instrs_memory_single_general_register (Rt, Rn,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsh_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -35818,7 +35818,7 @@ function decode_ldrsw_reg_aarch64_instrs_memory_single_general_register (Rt, Rn,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsw_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35837,7 +35837,7 @@ function decode_ldrsw_reg_aarch64_instrs_memory_single_general_register (Rt, Rn,
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldrsw_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -35919,7 +35919,7 @@ function decode_prfm_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_prfm_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -35938,7 +35938,7 @@ function decode_prfm_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_prfm_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -36019,7 +36019,7 @@ function decode_str_reg_gen_aarch64_instrs_memory_single_general_register (Rt, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_str_reg_gen_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -36038,7 +36038,7 @@ function decode_str_reg_gen_aarch64_instrs_memory_single_general_register (Rt, R
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_str_reg_gen_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -36116,7 +36116,7 @@ function decode_strb_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strb_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -36135,7 +36135,7 @@ function decode_strb_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strb_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -36213,7 +36213,7 @@ function decode_strh_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strh_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -36232,7 +36232,7 @@ function decode_strh_reg_aarch64_instrs_memory_single_general_register (Rt, Rn, 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_strh_reg_aarch64_instrs_memory_single_general_register")
         }
     };
     execute_aarch64_instrs_memory_single_general_register(datasize, extend_type, m, memop, n, nontemporal, postindex, regsize, rt_unknown, shift, is_signed, t, tagchecked, wb_unknown, wback)
@@ -36280,7 +36280,7 @@ function execute_aarch64_instrs_memory_single_simdfp_register (datasize, extend_
           assert(constraint('datasize in {8, 16, 32, 64, 128}));
           V_set(t, datasize) = data
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_single_simdfp_register")
     };
     if wback then {
         if postindex then {
@@ -36399,7 +36399,7 @@ function execute_aarch64_instrs_memory_single_general_immediate_signed_pac (memo
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_aarch64_instrs_memory_single_general_immediate_signed_pac")
         }
     };
     if n == 31 then {
@@ -36521,7 +36521,7 @@ function decode_ldsetp_aarch64_instrs_memory_atomicops_ld_128_ldsetp (Rt, Rn, op
       0b011 => {
           op = MemAtomicOp_ORR
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_ldsetp_aarch64_instrs_memory_atomicops_ld_128_ldsetp")
     };
     let acquire : bool = A == 0b1;
     let release : bool = R == 0b1;
@@ -36660,7 +36660,7 @@ function decode_ldtr_aarch64_instrs_memory_single_general_immediate_signed_offse
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtr_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -36679,7 +36679,7 @@ function decode_ldtr_aarch64_instrs_memory_single_general_immediate_signed_offse
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtr_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -36746,7 +36746,7 @@ function decode_ldtrb_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrb_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -36765,7 +36765,7 @@ function decode_ldtrb_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrb_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -36832,7 +36832,7 @@ function decode_ldtrh_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrh_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -36851,7 +36851,7 @@ function decode_ldtrh_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrh_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -36918,7 +36918,7 @@ function decode_ldtrsb_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrsb_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -36937,7 +36937,7 @@ function decode_ldtrsb_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrsb_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37004,7 +37004,7 @@ function decode_ldtrsh_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrsh_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37023,7 +37023,7 @@ function decode_ldtrsh_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrsh_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37090,7 +37090,7 @@ function decode_ldtrsw_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrsw_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37109,7 +37109,7 @@ function decode_ldtrsw_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldtrsw_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37176,7 +37176,7 @@ function decode_sttr_aarch64_instrs_memory_single_general_immediate_signed_offse
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sttr_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37195,7 +37195,7 @@ function decode_sttr_aarch64_instrs_memory_single_general_immediate_signed_offse
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sttr_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37262,7 +37262,7 @@ function decode_sttrb_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sttrb_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37281,7 +37281,7 @@ function decode_sttrb_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sttrb_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37348,7 +37348,7 @@ function decode_sttrh_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sttrh_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37367,7 +37367,7 @@ function decode_sttrh_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sttrh_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_unpriv(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37412,7 +37412,7 @@ function execute_aarch64_instrs_memory_single_simdfp_immediate_signed_offset_nor
           assert(constraint('datasize in {8, 16, 32, 64, 128}));
           V_set(t, datasize) = data
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_single_simdfp_immediate_signed_offset_normal")
     };
     if wback then {
         if postindex then {
@@ -37612,7 +37612,7 @@ function decode_ldur_gen_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldur_gen_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37631,7 +37631,7 @@ function decode_ldur_gen_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldur_gen_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37702,7 +37702,7 @@ function decode_ldurb_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldurb_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37721,7 +37721,7 @@ function decode_ldurb_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldurb_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37792,7 +37792,7 @@ function decode_ldurh_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldurh_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37811,7 +37811,7 @@ function decode_ldurh_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldurh_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37882,7 +37882,7 @@ function decode_ldursb_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldursb_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37901,7 +37901,7 @@ function decode_ldursb_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldursb_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -37972,7 +37972,7 @@ function decode_ldursh_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldursh_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -37991,7 +37991,7 @@ function decode_ldursh_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldursh_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -38062,7 +38062,7 @@ function decode_ldursw_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldursw_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -38081,7 +38081,7 @@ function decode_ldursw_aarch64_instrs_memory_single_general_immediate_signed_off
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_ldursw_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -38152,7 +38152,7 @@ function decode_prfum_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_prfum_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -38171,7 +38171,7 @@ function decode_prfum_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_prfum_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -38242,7 +38242,7 @@ function decode_stur_gen_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stur_gen_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -38261,7 +38261,7 @@ function decode_stur_gen_aarch64_instrs_memory_single_general_immediate_signed_o
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stur_gen_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -38332,7 +38332,7 @@ function decode_sturb_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sturb_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -38351,7 +38351,7 @@ function decode_sturb_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sturb_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -38422,7 +38422,7 @@ function decode_sturh_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sturh_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -38441,7 +38441,7 @@ function decode_sturh_aarch64_instrs_memory_single_general_immediate_signed_offs
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_sturh_aarch64_instrs_memory_single_general_immediate_signed_offset_normal")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_signed_offset_normal(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -39902,7 +39902,7 @@ function decode_prfm_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_prfm_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     if ((memop == MemOp_STORE & wback) & n == t) & n != 31 then {
@@ -39921,7 +39921,7 @@ function decode_prfm_imm_aarch64_instrs_memory_single_general_immediate_unsigned
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_prfm_imm_aarch64_instrs_memory_single_general_immediate_unsigned")
         }
     };
     execute_aarch64_instrs_memory_single_general_immediate_unsigned(datasize, memop, n, nontemporal, offset, postindex, regsize, rt_unknown, is_signed, t, tagchecked, wb_unknown, wback)
@@ -41233,7 +41233,7 @@ function decode_rev16_advsimd_aarch64_instrs_vector_arithmetic_unary_rev (Rd, Rn
       0b00 => {
           container_size = 64
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_rev16_advsimd_aarch64_instrs_vector_arithmetic_unary_rev")
     };
     let 'container_size = container_size;
     let 'containers = DIV(datasize, container_size);
@@ -41274,7 +41274,7 @@ function decode_rev32_advsimd_aarch64_instrs_vector_arithmetic_unary_rev (Rd, Rn
       0b00 => {
           container_size = 64
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_rev32_advsimd_aarch64_instrs_vector_arithmetic_unary_rev")
     };
     let 'container_size = container_size;
     let 'containers = DIV(datasize, container_size);
@@ -41315,7 +41315,7 @@ function decode_rev64_advsimd_aarch64_instrs_vector_arithmetic_unary_rev (Rd, Rn
       0b00 => {
           container_size = 64
       },
-      _ => ()
+      _ => PatternMatchFailure("decode_rev64_advsimd_aarch64_instrs_vector_arithmetic_unary_rev")
     };
     let 'container_size = container_size;
     let 'containers = DIV(datasize, container_size);
@@ -43124,7 +43124,7 @@ function decode_setp_aarch64_instrs_memory_mcpymset_set (Rd, Rn, op2, Rs, sz) = 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_setp_aarch64_instrs_memory_mcpymset_set")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_set(d, n, options_name, s, stage)
@@ -43180,7 +43180,7 @@ function decode_setpn_aarch64_instrs_memory_mcpymset_set (Rd, Rn, op2, Rs, sz) =
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_setpn_aarch64_instrs_memory_mcpymset_set")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_set(d, n, options_name, s, stage)
@@ -43236,7 +43236,7 @@ function decode_setpt_aarch64_instrs_memory_mcpymset_set (Rd, Rn, op2, Rs, sz) =
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_setpt_aarch64_instrs_memory_mcpymset_set")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_set(d, n, options_name, s, stage)
@@ -43292,7 +43292,7 @@ function decode_setptn_aarch64_instrs_memory_mcpymset_set (Rd, Rn, op2, Rs, sz) 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_setptn_aarch64_instrs_memory_mcpymset_set")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_set(d, n, options_name, s, stage)
@@ -43537,7 +43537,7 @@ function decode_setgp_aarch64_instrs_memory_mcpymset_setg (Rd, Rn, op2, Rs, sz) 
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_setgp_aarch64_instrs_memory_mcpymset_setg")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_setg(d, n, options_name, s, stage)
@@ -43596,7 +43596,7 @@ function decode_setgpn_aarch64_instrs_memory_mcpymset_setg (Rd, Rn, op2, Rs, sz)
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_setgpn_aarch64_instrs_memory_mcpymset_setg")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_setg(d, n, options_name, s, stage)
@@ -43655,7 +43655,7 @@ function decode_setgpt_aarch64_instrs_memory_mcpymset_setg (Rd, Rn, op2, Rs, sz)
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_setgpt_aarch64_instrs_memory_mcpymset_setg")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_setg(d, n, options_name, s, stage)
@@ -43714,7 +43714,7 @@ function decode_setgptn_aarch64_instrs_memory_mcpymset_setg (Rd, Rn, op2, Rs, sz
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_setgptn_aarch64_instrs_memory_mcpymset_setg")
         }
     };
     execute_aarch64_instrs_memory_mcpymset_setg(d, n, options_name, s, stage)
@@ -51034,7 +51034,7 @@ function execute_aarch64_instrs_memory_ordered_pair_stilp (datasize, memop, n, o
           X_set(t, datasize) = data1;
           X_set(t2, datasize) = data2
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_aarch64_instrs_memory_ordered_pair_stilp")
     };
     if wback then {
         if wb_unknown then {
@@ -51093,7 +51093,7 @@ function decode_stilp_aarch64_instrs_memory_ordered_pair_stilp (Rt, Rn, opc2, Rt
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stilp_aarch64_instrs_memory_ordered_pair_stilp")
         }
     };
     if ((memop == MemOp_STORE & wback) & (t == n | t2 == n)) & n != 31 then {
@@ -51112,7 +51112,7 @@ function decode_stilp_aarch64_instrs_memory_ordered_pair_stilp (Rt, Rn, opc2, Rt
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stilp_aarch64_instrs_memory_ordered_pair_stilp")
         }
     };
     if memop == MemOp_LOAD & t == t2 then {
@@ -51128,7 +51128,7 @@ function decode_stilp_aarch64_instrs_memory_ordered_pair_stilp (Rt, Rn, opc2, Rt
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("decode_stilp_aarch64_instrs_memory_ordered_pair_stilp")
         }
     };
     assert(constraint('datasize in {32, 64}));
@@ -52395,8 +52395,7 @@ function decode_tstart_aarch64_instrs_system_tme_tstart Rt = {
       },
       2048 => {
           execute_aarch64_instrs_system_tme_tstart(2048, t)
-      },
-      _ => ()
+      }
     }
 }
 

--- a/arm-v9.4-a/src/instrs64_sme.sail
+++ b/arm-v9.4-a/src/instrs64_sme.sail
@@ -100,8 +100,7 @@ function decode_FMOPA_ZA_PP_ZZ_32 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_FMOPA_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -178,8 +177,7 @@ function decode_FMOPS_ZA_PP_ZZ_32 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_FMOPS_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -256,8 +254,7 @@ function decode_FMOPA_ZA_PP_ZZ_64 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_FMOPA_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -334,8 +331,7 @@ function decode_FMOPS_ZA_PP_ZZ_64 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_FMOPS_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -435,8 +431,7 @@ function decode_BFMOPA_ZA32_PP_ZZ__ (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_BFMOPA_ZA32_PP_ZZ__(2048, DIV(2048, 32) * DIV(2048, 32) * 32, a, b, da, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -536,8 +531,7 @@ function decode_BFMOPS_ZA32_PP_ZZ__ (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_BFMOPS_ZA32_PP_ZZ__(2048, DIV(2048, 32) * DIV(2048, 32) * 32, a, b, da, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -636,8 +630,7 @@ function decode_FMOPA_ZA32_PP_ZZ_16 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_FMOPA_ZA32_PP_ZZ_16(2048, DIV(2048, 32) * DIV(2048, 32) * 32, a, b, da, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -736,8 +729,7 @@ function decode_FMOPS_ZA32_PP_ZZ_16 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_FMOPS_ZA32_PP_ZZ_16(2048, DIV(2048, 32) * DIV(2048, 32) * 32, a, b, da, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -818,8 +810,7 @@ function decode_SMOPA_ZA_PP_ZZ_32 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SMOPA_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -902,8 +893,7 @@ function decode_SUMOPA_ZA_PP_ZZ_32 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SUMOPA_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -986,8 +976,7 @@ function decode_USMOPA_ZA_PP_ZZ_32 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_USMOPA_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1070,8 +1059,7 @@ function decode_UMOPA_ZA_PP_ZZ_32 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_UMOPA_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1154,8 +1142,7 @@ function decode_SMOPS_ZA_PP_ZZ_32 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SMOPS_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1238,8 +1225,7 @@ function decode_SUMOPS_ZA_PP_ZZ_32 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SUMOPS_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1322,8 +1308,7 @@ function decode_USMOPS_ZA_PP_ZZ_32 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_USMOPS_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1406,8 +1391,7 @@ function decode_UMOPS_ZA_PP_ZZ_32 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_UMOPS_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1490,8 +1474,7 @@ function decode_SMOPA_ZA_PP_ZZ_64 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SMOPA_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1574,8 +1557,7 @@ function decode_SUMOPA_ZA_PP_ZZ_64 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SUMOPA_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1658,8 +1640,7 @@ function decode_USMOPA_ZA_PP_ZZ_64 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_USMOPA_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1742,8 +1723,7 @@ function decode_UMOPA_ZA_PP_ZZ_64 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_UMOPA_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1826,8 +1806,7 @@ function decode_SMOPS_ZA_PP_ZZ_64 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SMOPS_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1910,8 +1889,7 @@ function decode_SUMOPS_ZA_PP_ZZ_64 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SUMOPS_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1994,8 +1972,7 @@ function decode_USMOPS_ZA_PP_ZZ_64 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_USMOPS_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2078,8 +2055,7 @@ function decode_UMOPS_ZA_PP_ZZ_64 (u0, u1, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_UMOPS_ZA_PP_ZZ_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, op1_unsigned, op2_unsigned, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2149,8 +2125,7 @@ function decode_MOVA_ZA_P_RZ_B (size, Q, V, Rs, Pg, Zn, off4) = {
       },
       2048 => {
           execute_MOVA_ZA_P_RZ_B(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2219,8 +2194,7 @@ function decode_MOVA_ZA_P_RZ_H (size, Q, V, Rs, Pg, Zn, ZAd, off3) = {
       },
       2048 => {
           execute_MOVA_ZA_P_RZ_H(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2290,8 +2264,7 @@ function decode_MOVA_ZA_P_RZ_W (size, Q, V, Rs, Pg, Zn, ZAd, off2) = {
       },
       2048 => {
           execute_MOVA_ZA_P_RZ_W(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2361,8 +2334,7 @@ function decode_MOVA_ZA_P_RZ_D (size, Q, V, Rs, Pg, Zn, ZAd, o1) = {
       },
       2048 => {
           execute_MOVA_ZA_P_RZ_D(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2432,8 +2404,7 @@ function decode_MOVA_ZA_P_RZ_Q (size, Q, V, Rs, Pg, Zn, ZAd) = {
       },
       2048 => {
           execute_MOVA_ZA_P_RZ_Q(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2502,8 +2473,7 @@ function decode_MOVA_Z_P_RZA_B (size, Q, V, Rs, Pg, off4, Zd) = {
       },
       2048 => {
           execute_MOVA_Z_P_RZA_B(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2572,8 +2542,7 @@ function decode_MOVA_Z_P_RZA_H (size, Q, V, Rs, Pg, ZAn, off3, Zd) = {
       },
       2048 => {
           execute_MOVA_Z_P_RZA_H(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2643,8 +2612,7 @@ function decode_MOVA_Z_P_RZA_W (size, Q, V, Rs, Pg, ZAn, off2, Zd) = {
       },
       2048 => {
           execute_MOVA_Z_P_RZA_W(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2714,8 +2682,7 @@ function decode_MOVA_Z_P_RZA_D (size, Q, V, Rs, Pg, ZAn, o1, Zd) = {
       },
       2048 => {
           execute_MOVA_Z_P_RZA_D(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2785,8 +2752,7 @@ function decode_MOVA_Z_P_RZA_Q (size, Q, V, Rs, Pg, ZAn, Zd) = {
       },
       2048 => {
           execute_MOVA_Z_P_RZA_Q(2048, d, esize, g, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2867,8 +2833,7 @@ function decode_LDR_ZA_RI__ (Rv, Rn, off4) = {
       },
       2048 => {
           execute_LDR_ZA_RI__(2048, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2944,8 +2909,7 @@ function decode_STR_ZA_RI__ (Rv, Rn, off4) = {
       },
       2048 => {
           execute_STR_ZA_RI__(2048, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3028,8 +2992,7 @@ function decode_LD1B_ZA_P_RRR__ (msz, Rm, V, Rs, Pg, Rn, off4) = {
       },
       2048 => {
           execute_LD1B_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3116,8 +3079,7 @@ function decode_LD1H_ZA_P_RRR__ (msz, Rm, V, Rs, Pg, Rn, ZAt, off3) = {
       },
       2048 => {
           execute_LD1H_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3205,8 +3167,7 @@ function decode_LD1W_ZA_P_RRR__ (msz, Rm, V, Rs, Pg, Rn, ZAt, off2) = {
       },
       2048 => {
           execute_LD1W_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3294,8 +3255,7 @@ function decode_LD1D_ZA_P_RRR__ (msz, Rm, V, Rs, Pg, Rn, ZAt, o1) = {
       },
       2048 => {
           execute_LD1D_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3383,8 +3343,7 @@ function decode_LD1Q_ZA_P_RRR__ (Rm, V, Rs, Pg, Rn, ZAt) = {
       },
       2048 => {
           execute_LD1Q_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3467,8 +3426,7 @@ function decode_ST1B_ZA_P_RRR__ (msz, Rm, V, Rs, Pg, Rn, off4) = {
       },
       2048 => {
           execute_ST1B_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3552,8 +3510,7 @@ function decode_ST1H_ZA_P_RRR__ (msz, Rm, V, Rs, Pg, Rn, ZAt, off3) = {
       },
       2048 => {
           execute_ST1H_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3638,8 +3595,7 @@ function decode_ST1W_ZA_P_RRR__ (msz, Rm, V, Rs, Pg, Rn, ZAt, off2) = {
       },
       2048 => {
           execute_ST1W_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3724,8 +3680,7 @@ function decode_ST1D_ZA_P_RRR__ (msz, Rm, V, Rs, Pg, Rn, ZAt, o1) = {
       },
       2048 => {
           execute_ST1D_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3810,8 +3765,7 @@ function decode_ST1Q_ZA_P_RRR__ (Rm, V, Rs, Pg, Rn, ZAt) = {
       },
       2048 => {
           execute_ST1Q_ZA_P_RRR__(2048, esize, g, m, n, offset, s, t, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3880,8 +3834,7 @@ function decode_ADDHA_ZA_PP_Z_32 (V, Pm, Pn, Zn, ZAda) = {
       },
       2048 => {
           execute_ADDHA_ZA_PP_Z_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3949,8 +3902,7 @@ function decode_ADDHA_ZA_PP_Z_64 (V, Pm, Pn, Zn, ZAda) = {
       },
       2048 => {
           execute_ADDHA_ZA_PP_Z_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4018,8 +3970,7 @@ function decode_ADDVA_ZA_PP_Z_32 (V, Pm, Pn, Zn, ZAda) = {
       },
       2048 => {
           execute_ADDVA_ZA_PP_Z_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4087,8 +4038,7 @@ function decode_ADDVA_ZA_PP_Z_64 (V, Pm, Pn, Zn, ZAda) = {
       },
       2048 => {
           execute_ADDVA_ZA_PP_Z_64(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4146,8 +4096,7 @@ function decode_ZERO_ZA_I__ imm8 = {
       },
       2048 => {
           execute_ZERO_ZA_I__(2048, DIV(2048, esize) * DIV(2048, esize) * esize, esize, mask)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4205,8 +4154,7 @@ function decode_MOVA_ZA2_Z_B1 (size, V, Rs, Zn, off3) = {
       },
       2048 => {
           execute_MOVA_ZA2_Z_B1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4268,8 +4216,7 @@ function decode_MOVA_ZA2_Z_H1 (size, V, Rs, Zn, ZAd, off2) = {
       },
       2048 => {
           execute_MOVA_ZA2_Z_H1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4332,8 +4279,7 @@ function decode_MOVA_ZA2_Z_W1 (size, V, Rs, Zn, ZAd, o1) = {
       },
       2048 => {
           execute_MOVA_ZA2_Z_W1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4396,8 +4342,7 @@ function decode_MOVA_ZA2_Z_D1 (size, V, Rs, Zn, ZAd) = {
       },
       2048 => {
           execute_MOVA_ZA2_Z_D1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4459,8 +4404,7 @@ function decode_MOVA_ZA4_Z_B1 (size, V, Rs, Zn, off2) = {
       },
       2048 => {
           execute_MOVA_ZA4_Z_B1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4522,8 +4466,7 @@ function decode_MOVA_ZA4_Z_H1 (size, V, Rs, Zn, ZAd, o1) = {
       },
       2048 => {
           execute_MOVA_ZA4_Z_H1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4586,8 +4529,7 @@ function decode_MOVA_ZA4_Z_W1 (size, V, Rs, Zn, ZAd) = {
       },
       2048 => {
           execute_MOVA_ZA4_Z_W1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4649,8 +4591,7 @@ function decode_MOVA_ZA4_Z_D1 (size, V, Rs, Zn, ZAd) = {
       },
       2048 => {
           execute_MOVA_ZA4_Z_D1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4711,8 +4652,7 @@ function decode_MOVA_ZA_MZ2_1 (Rv, Zn, off3) = {
       },
       2048 => {
           execute_MOVA_ZA_MZ2_1(2048, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4771,8 +4711,7 @@ function decode_MOVA_ZA_MZ4_1 (Rv, Zn, off3) = {
       },
       2048 => {
           execute_MOVA_ZA_MZ4_1(2048, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4832,8 +4771,7 @@ function decode_MOVA_MZ2_ZA_B1 (size, V, Rs, off3, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ2_ZA_B1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4895,8 +4833,7 @@ function decode_MOVA_MZ2_ZA_H1 (size, V, Rs, ZAn, off2, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ2_ZA_H1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4959,8 +4896,7 @@ function decode_MOVA_MZ2_ZA_W1 (size, V, Rs, ZAn, o1, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ2_ZA_W1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5023,8 +4959,7 @@ function decode_MOVA_MZ2_ZA_D1 (size, V, Rs, ZAn, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ2_ZA_D1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5086,8 +5021,7 @@ function decode_MOVA_MZ4_ZA_B1 (size, V, Rs, off2, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ4_ZA_B1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5149,8 +5083,7 @@ function decode_MOVA_MZ4_ZA_H1 (size, V, Rs, ZAn, o1, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ4_ZA_H1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5213,8 +5146,7 @@ function decode_MOVA_MZ4_ZA_W1 (size, V, Rs, ZAn, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ4_ZA_W1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5276,8 +5208,7 @@ function decode_MOVA_MZ4_ZA_D1 (size, V, Rs, ZAn, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ4_ZA_D1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5338,8 +5269,7 @@ function decode_MOVA_MZ_ZA2_1 (Rv, off3, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ_ZA2_1(2048, d, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5398,8 +5328,7 @@ function decode_MOVA_MZ_ZA4_1 (Rv, off3, Zd) = {
       },
       2048 => {
           execute_MOVA_MZ_ZA4_1(2048, d, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5488,8 +5417,7 @@ function decode_LD1B_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1B_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5582,8 +5510,7 @@ function decode_LD1H_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1H_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5676,8 +5603,7 @@ function decode_LD1W_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1W_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5770,8 +5696,7 @@ function decode_LD1D_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1D_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5864,8 +5789,7 @@ function decode_LD1B_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1B_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5958,8 +5882,7 @@ function decode_LD1H_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1H_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6052,8 +5975,7 @@ function decode_LD1W_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1W_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6146,8 +6068,7 @@ function decode_LD1D_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1D_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6240,8 +6161,7 @@ function decode_LDNT1B_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1B_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6334,8 +6254,7 @@ function decode_LDNT1H_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1H_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6428,8 +6347,7 @@ function decode_LDNT1W_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1W_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6522,8 +6440,7 @@ function decode_LDNT1D_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1D_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6616,8 +6533,7 @@ function decode_LDNT1B_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1B_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6710,8 +6626,7 @@ function decode_LDNT1H_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1H_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6804,8 +6719,7 @@ function decode_LDNT1W_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1W_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6898,8 +6812,7 @@ function decode_LDNT1D_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1D_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6989,8 +6902,7 @@ function decode_ST1B_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1B_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7080,8 +6992,7 @@ function decode_ST1H_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1H_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7171,8 +7082,7 @@ function decode_ST1W_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1W_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7262,8 +7172,7 @@ function decode_ST1D_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1D_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7353,8 +7262,7 @@ function decode_ST1B_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1B_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7444,8 +7352,7 @@ function decode_ST1H_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1H_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7535,8 +7442,7 @@ function decode_ST1W_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1W_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7626,8 +7532,7 @@ function decode_ST1D_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1D_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7717,8 +7622,7 @@ function decode_STNT1B_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1B_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7808,8 +7712,7 @@ function decode_STNT1H_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1H_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7899,8 +7802,7 @@ function decode_STNT1W_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1W_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7990,8 +7892,7 @@ function decode_STNT1D_MZx_P_BR_2x8 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1D_MZx_P_BR_2x8(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8081,8 +7982,7 @@ function decode_STNT1B_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1B_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8172,8 +8072,7 @@ function decode_STNT1H_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1H_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8263,8 +8162,7 @@ function decode_STNT1W_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1W_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8354,8 +8252,7 @@ function decode_STNT1D_MZx_P_BR_4x4 (Rm, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1D_MZx_P_BR_4x4(2048, esize, g, m, n, nreg, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8446,8 +8343,7 @@ function decode_LD1B_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1B_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8538,8 +8434,7 @@ function decode_LD1H_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1H_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8630,8 +8525,7 @@ function decode_LD1W_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1W_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8722,8 +8616,7 @@ function decode_LD1D_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1D_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8814,8 +8707,7 @@ function decode_LDNT1B_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1B_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8906,8 +8798,7 @@ function decode_LDNT1H_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1H_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8998,8 +8889,7 @@ function decode_LDNT1W_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1W_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9090,8 +8980,7 @@ function decode_LDNT1D_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1D_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9182,8 +9071,7 @@ function decode_LD1B_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1B_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9274,8 +9162,7 @@ function decode_LD1H_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1H_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9366,8 +9253,7 @@ function decode_LD1W_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1W_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9458,8 +9344,7 @@ function decode_LD1D_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LD1D_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9550,8 +9435,7 @@ function decode_LDNT1B_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1B_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9642,8 +9526,7 @@ function decode_LDNT1H_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1H_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9734,8 +9617,7 @@ function decode_LDNT1W_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1W_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9826,8 +9708,7 @@ function decode_LDNT1D_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_LDNT1D_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9915,8 +9796,7 @@ function decode_ST1B_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1B_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10004,8 +9884,7 @@ function decode_ST1H_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1H_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10093,8 +9972,7 @@ function decode_ST1W_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1W_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10182,8 +10060,7 @@ function decode_ST1D_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1D_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10271,8 +10148,7 @@ function decode_ST1B_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1B_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10360,8 +10236,7 @@ function decode_ST1H_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1H_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10449,8 +10324,7 @@ function decode_ST1W_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1W_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10538,8 +10412,7 @@ function decode_ST1D_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_ST1D_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10627,8 +10500,7 @@ function decode_STNT1B_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1B_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10716,8 +10588,7 @@ function decode_STNT1H_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1H_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10805,8 +10676,7 @@ function decode_STNT1W_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1W_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10894,8 +10764,7 @@ function decode_STNT1D_MZx_P_BI_2x8 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1D_MZx_P_BI_2x8(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10983,8 +10852,7 @@ function decode_STNT1B_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1B_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11072,8 +10940,7 @@ function decode_STNT1H_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1H_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11161,8 +11028,7 @@ function decode_STNT1W_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1W_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11250,8 +11116,7 @@ function decode_STNT1D_MZx_P_BI_4x4 (imm4, msz, PNg, Rn, T, N, Zt) = {
       },
       2048 => {
           execute_STNT1D_MZx_P_BI_4x4(2048, esize, g, n, nreg, offset, t, tstride)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11329,8 +11194,7 @@ function decode_FADD_ZA_ZW_2x2 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_FADD_ZA_ZW_2x2(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11406,8 +11270,7 @@ function decode_FSUB_ZA_ZW_2x2 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_FSUB_ZA_ZW_2x2(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11483,8 +11346,7 @@ function decode_FADD_ZA_ZW_4x4 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_FADD_ZA_ZW_4x4(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11560,8 +11422,7 @@ function decode_FSUB_ZA_ZW_4x4 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_FSUB_ZA_ZW_4x4(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11644,8 +11505,7 @@ function decode_FMLA_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11729,8 +11589,7 @@ function decode_FMLS_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11814,8 +11673,7 @@ function decode_FMLA_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11899,8 +11757,7 @@ function decode_FMLS_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11984,8 +11841,7 @@ function decode_FMLA_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12069,8 +11925,7 @@ function decode_FMLS_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12154,8 +12009,7 @@ function decode_FMLA_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12239,8 +12093,7 @@ function decode_FMLS_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12325,8 +12178,7 @@ function decode_FMLA_ZA_ZZi_S2xi (Zm, Rv, i2, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12411,8 +12263,7 @@ function decode_FMLS_ZA_ZZi_S2xi (Zm, Rv, i2, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12497,8 +12348,7 @@ function decode_FMLA_ZA_ZZi_D2xi (Zm, Rv, i1, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZi_D2xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12583,8 +12433,7 @@ function decode_FMLS_ZA_ZZi_D2xi (Zm, Rv, i1, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZi_D2xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12669,8 +12518,7 @@ function decode_FMLA_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12755,8 +12603,7 @@ function decode_FMLS_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12841,8 +12688,7 @@ function decode_FMLA_ZA_ZZi_D4xi (Zm, Rv, i1, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZi_D4xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12927,8 +12773,7 @@ function decode_FMLS_ZA_ZZi_D4xi (Zm, Rv, i1, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZi_D4xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13007,8 +12852,7 @@ function decode_BFDOT_ZA_ZZW_2x2 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_BFDOT_ZA_ZZW_2x2(2048, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13085,8 +12929,7 @@ function decode_BFDOT_ZA_ZZV_2x1 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_BFDOT_ZA_ZZV_2x1(2048, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13163,8 +13006,7 @@ function decode_FDOT_ZA_ZZW_2x2 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_FDOT_ZA_ZZW_2x2(2048, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13241,8 +13083,7 @@ function decode_FDOT_ZA_ZZV_2x1 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_FDOT_ZA_ZZV_2x1(2048, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13319,8 +13160,7 @@ function decode_BFDOT_ZA_ZZW_4x4 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_BFDOT_ZA_ZZW_4x4(2048, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13397,8 +13237,7 @@ function decode_BFDOT_ZA_ZZV_4x1 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_BFDOT_ZA_ZZV_4x1(2048, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13475,8 +13314,7 @@ function decode_FDOT_ZA_ZZW_4x4 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_FDOT_ZA_ZZW_4x4(2048, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13553,8 +13391,7 @@ function decode_FDOT_ZA_ZZV_4x1 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_FDOT_ZA_ZZV_4x1(2048, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13635,8 +13472,7 @@ function decode_BFDOT_ZA_ZZi_2xi (Zm, Rv, i2, Zn, off3) = {
       },
       2048 => {
           execute_BFDOT_ZA_ZZi_2xi(2048, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13718,8 +13554,7 @@ function decode_BFDOT_ZA_ZZi_4xi (Zm, Rv, i2, Zn, off3) = {
       },
       2048 => {
           execute_BFDOT_ZA_ZZi_4xi(2048, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13801,8 +13636,7 @@ function decode_FDOT_ZA_ZZi_2xi (Zm, Rv, i2, Zn, off3) = {
       },
       2048 => {
           execute_FDOT_ZA_ZZi_2xi(2048, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13884,8 +13718,7 @@ function decode_FDOT_ZA_ZZi_4xi (Zm, Rv, i2, Zn, off3) = {
       },
       2048 => {
           execute_FDOT_ZA_ZZi_4xi(2048, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13967,8 +13800,7 @@ function decode_BFVDOT_ZA_ZZi_2xi (Zm, Rv, i2, Zn, off3) = {
       },
       2048 => {
           execute_BFVDOT_ZA_ZZi_2xi(2048, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14050,8 +13882,7 @@ function decode_FVDOT_ZA_ZZi_2xi (Zm, Rv, i2, Zn, off3) = {
       },
       2048 => {
           execute_FVDOT_ZA_ZZi_2xi(2048, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14130,8 +13961,7 @@ function decode_BFMLAL_ZA_ZZV_1 (Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLAL_ZA_ZZV_1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14210,8 +14040,7 @@ function decode_BFMLAL_ZA_ZZW_2x2 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_BFMLAL_ZA_ZZW_2x2(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14290,8 +14119,7 @@ function decode_BFMLAL_ZA_ZZV_2x1 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_BFMLAL_ZA_ZZV_2x1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14370,8 +14198,7 @@ function decode_BFMLAL_ZA_ZZW_4x4 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_BFMLAL_ZA_ZZW_4x4(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14450,8 +14277,7 @@ function decode_BFMLAL_ZA_ZZV_4x1 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_BFMLAL_ZA_ZZV_4x1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14530,8 +14356,7 @@ function decode_BFMLSL_ZA_ZZV_1 (Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLSL_ZA_ZZV_1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14610,8 +14435,7 @@ function decode_BFMLSL_ZA_ZZW_2x2 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_BFMLSL_ZA_ZZW_2x2(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14690,8 +14514,7 @@ function decode_BFMLSL_ZA_ZZV_2x1 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_BFMLSL_ZA_ZZV_2x1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14770,8 +14593,7 @@ function decode_BFMLSL_ZA_ZZW_4x4 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_BFMLSL_ZA_ZZW_4x4(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14850,8 +14672,7 @@ function decode_BFMLSL_ZA_ZZV_4x1 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_BFMLSL_ZA_ZZV_4x1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14934,8 +14755,7 @@ function decode_BFMLAL_ZA_ZZi_1 (Zm, i3h, Rv, i3l, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLAL_ZA_ZZi_1(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15020,8 +14840,7 @@ function decode_BFMLAL_ZA_ZZi_2xi (Zm, Rv, i3h, Zn, S, i3l, off2) = {
       },
       2048 => {
           execute_BFMLAL_ZA_ZZi_2xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15106,8 +14925,7 @@ function decode_BFMLAL_ZA_ZZi_4xi (Zm, Rv, i3h, Zn, S, i3l, off2) = {
       },
       2048 => {
           execute_BFMLAL_ZA_ZZi_4xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15192,8 +15010,7 @@ function decode_BFMLSL_ZA_ZZi_1 (Zm, i3h, Rv, i3l, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLSL_ZA_ZZi_1(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15278,8 +15095,7 @@ function decode_BFMLSL_ZA_ZZi_2xi (Zm, Rv, i3h, Zn, S, i3l, off2) = {
       },
       2048 => {
           execute_BFMLSL_ZA_ZZi_2xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15364,8 +15180,7 @@ function decode_BFMLSL_ZA_ZZi_4xi (Zm, Rv, i3h, Zn, S, i3l, off2) = {
       },
       2048 => {
           execute_BFMLSL_ZA_ZZi_4xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15446,8 +15261,7 @@ function decode_FMLAL_ZA_ZZV_1 (Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLAL_ZA_ZZV_1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15526,8 +15340,7 @@ function decode_FMLAL_ZA_ZZW_2x2 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_FMLAL_ZA_ZZW_2x2(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15606,8 +15419,7 @@ function decode_FMLAL_ZA_ZZV_2x1 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_FMLAL_ZA_ZZV_2x1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15686,8 +15498,7 @@ function decode_FMLAL_ZA_ZZW_4x4 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_FMLAL_ZA_ZZW_4x4(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15766,8 +15577,7 @@ function decode_FMLAL_ZA_ZZV_4x1 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_FMLAL_ZA_ZZV_4x1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15850,8 +15660,7 @@ function decode_FMLAL_ZA_ZZi_1 (Zm, i3h, Rv, i3l, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLAL_ZA_ZZi_1(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15936,8 +15745,7 @@ function decode_FMLAL_ZA_ZZi_2xi (Zm, Rv, i3h, Zn, S, i3l, off2) = {
       },
       2048 => {
           execute_FMLAL_ZA_ZZi_2xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16022,8 +15830,7 @@ function decode_FMLAL_ZA_ZZi_4xi (Zm, Rv, i3h, Zn, S, i3l, off2) = {
       },
       2048 => {
           execute_FMLAL_ZA_ZZi_4xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16104,8 +15911,7 @@ function decode_FMLSL_ZA_ZZV_1 (Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLSL_ZA_ZZV_1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16184,8 +15990,7 @@ function decode_FMLSL_ZA_ZZW_2x2 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_FMLSL_ZA_ZZW_2x2(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16264,8 +16069,7 @@ function decode_FMLSL_ZA_ZZV_2x1 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_FMLSL_ZA_ZZV_2x1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16344,8 +16148,7 @@ function decode_FMLSL_ZA_ZZW_4x4 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_FMLSL_ZA_ZZW_4x4(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16424,8 +16227,7 @@ function decode_FMLSL_ZA_ZZV_4x1 (Zm, Rv, Zn, S, off2) = {
       },
       2048 => {
           execute_FMLSL_ZA_ZZV_4x1(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16508,8 +16310,7 @@ function decode_FMLSL_ZA_ZZi_1 (Zm, i3h, Rv, i3l, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLSL_ZA_ZZi_1(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16594,8 +16395,7 @@ function decode_FMLSL_ZA_ZZi_2xi (Zm, Rv, i3h, Zn, S, i3l, off2) = {
       },
       2048 => {
           execute_FMLSL_ZA_ZZi_2xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16680,8 +16480,7 @@ function decode_FMLSL_ZA_ZZi_4xi (Zm, Rv, i3h, Zn, S, i3l, off2) = {
       },
       2048 => {
           execute_FMLSL_ZA_ZZi_4xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16747,8 +16546,7 @@ function decode_FMAX_MZ_ZZW_2x2 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAX_MZ_ZZW_2x2(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16810,8 +16608,7 @@ function decode_FMAX_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAX_MZ_ZZV_2x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16873,8 +16670,7 @@ function decode_FMIN_MZ_ZZW_2x2 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMIN_MZ_ZZW_2x2(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16936,8 +16732,7 @@ function decode_FMIN_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMIN_MZ_ZZV_2x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16999,8 +16794,7 @@ function decode_FMAX_MZ_ZZW_4x4 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAX_MZ_ZZW_4x4(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17062,8 +16856,7 @@ function decode_FMAX_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAX_MZ_ZZV_4x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17125,8 +16918,7 @@ function decode_FMIN_MZ_ZZW_4x4 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMIN_MZ_ZZW_4x4(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17188,8 +16980,7 @@ function decode_FMIN_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMIN_MZ_ZZV_4x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17251,8 +17042,7 @@ function decode_FMAXNM_MZ_ZZW_2x2 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAXNM_MZ_ZZW_2x2(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17314,8 +17104,7 @@ function decode_FMAXNM_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAXNM_MZ_ZZV_2x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17377,8 +17166,7 @@ function decode_FMINNM_MZ_ZZW_2x2 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMINNM_MZ_ZZW_2x2(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17440,8 +17228,7 @@ function decode_FMINNM_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMINNM_MZ_ZZV_2x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17503,8 +17290,7 @@ function decode_FMAXNM_MZ_ZZW_4x4 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAXNM_MZ_ZZW_4x4(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17566,8 +17352,7 @@ function decode_FMAXNM_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAXNM_MZ_ZZV_4x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17629,8 +17414,7 @@ function decode_FMINNM_MZ_ZZW_4x4 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMINNM_MZ_ZZW_4x4(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17692,8 +17476,7 @@ function decode_FMINNM_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_FMINNM_MZ_ZZV_4x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17758,8 +17541,7 @@ function decode_FCLAMP_MZ_ZZ_2 (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FCLAMP_MZ_ZZ_2(2048, d, esize, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17825,8 +17607,7 @@ function decode_FCLAMP_MZ_ZZ_4 (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FCLAMP_MZ_ZZ_4(2048, d, esize, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17885,8 +17666,7 @@ function decode_BFCVT_Z_MZ2__ (Zn, N, Zd) = {
       },
       2048 => {
           execute_BFCVT_Z_MZ2__(2048, d, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17944,8 +17724,7 @@ function decode_FCVT_Z_MZ2__ (Zn, N, Zd) = {
       },
       2048 => {
           execute_FCVT_Z_MZ2__(2048, d, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18003,8 +17782,7 @@ function decode_BFCVTN_Z_MZ2__ (Zn, N, Zd) = {
       },
       2048 => {
           execute_BFCVTN_Z_MZ2__(2048, d, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18062,8 +17840,7 @@ function decode_FCVTN_Z_MZ2__ (Zn, N, Zd) = {
       },
       2048 => {
           execute_FCVTN_Z_MZ2__(2048, d, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18123,8 +17900,7 @@ function decode_FCVTZU_MZ_Z_2 (Zn, U, Zd) = {
       },
       2048 => {
           execute_FCVTZU_MZ_Z_2(2048, d, n, nreg, rounding, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18184,8 +17960,7 @@ function decode_FCVTZU_MZ_Z_4 (Zn, U, Zd) = {
       },
       2048 => {
           execute_FCVTZU_MZ_Z_4(2048, d, n, nreg, rounding, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18245,8 +18020,7 @@ function decode_FCVTZS_MZ_Z_2 (Zn, U, Zd) = {
       },
       2048 => {
           execute_FCVTZS_MZ_Z_2(2048, d, n, nreg, rounding, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18306,8 +18080,7 @@ function decode_FCVTZS_MZ_Z_4 (Zn, U, Zd) = {
       },
       2048 => {
           execute_FCVTZS_MZ_Z_4(2048, d, n, nreg, rounding, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18367,8 +18140,7 @@ function decode_UCVTF_MZ_Z_2 (Zn, U, Zd) = {
       },
       2048 => {
           execute_UCVTF_MZ_Z_2(2048, d, n, nreg, rounding, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18428,8 +18200,7 @@ function decode_UCVTF_MZ_Z_4 (Zn, U, Zd) = {
       },
       2048 => {
           execute_UCVTF_MZ_Z_4(2048, d, n, nreg, rounding, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18489,8 +18260,7 @@ function decode_SCVTF_MZ_Z_2 (Zn, U, Zd) = {
       },
       2048 => {
           execute_SCVTF_MZ_Z_2(2048, d, n, nreg, rounding, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18550,8 +18320,7 @@ function decode_SCVTF_MZ_Z_4 (Zn, U, Zd) = {
       },
       2048 => {
           execute_SCVTF_MZ_Z_4(2048, d, n, nreg, rounding, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18611,8 +18380,7 @@ function decode_FRINTA_MZ_Z_2 (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTA_MZ_Z_2(2048, d, exact, n, nreg, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18672,8 +18440,7 @@ function decode_FRINTM_MZ_Z_2 (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTM_MZ_Z_2(2048, d, exact, n, nreg, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18733,8 +18500,7 @@ function decode_FRINTN_MZ_Z_2 (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTN_MZ_Z_2(2048, d, exact, n, nreg, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18794,8 +18560,7 @@ function decode_FRINTP_MZ_Z_2 (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTP_MZ_Z_2(2048, d, exact, n, nreg, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18855,8 +18620,7 @@ function decode_FRINTA_MZ_Z_4 (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTA_MZ_Z_4(2048, d, exact, n, nreg, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18916,8 +18680,7 @@ function decode_FRINTM_MZ_Z_4 (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTM_MZ_Z_4(2048, d, exact, n, nreg, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18977,8 +18740,7 @@ function decode_FRINTN_MZ_Z_4 (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTN_MZ_Z_4(2048, d, exact, n, nreg, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19038,8 +18800,7 @@ function decode_FRINTP_MZ_Z_4 (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTP_MZ_Z_4(2048, d, exact, n, nreg, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19113,8 +18874,7 @@ function decode_ADD_ZA_ZW_2x2 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_ADD_ZA_ZW_2x2(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19190,8 +18950,7 @@ function decode_SUB_ZA_ZW_2x2 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_SUB_ZA_ZW_2x2(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19267,8 +19026,7 @@ function decode_ADD_ZA_ZW_4x4 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_ADD_ZA_ZW_4x4(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19344,8 +19102,7 @@ function decode_SUB_ZA_ZW_4x4 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_SUB_ZA_ZW_4x4(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19419,8 +19176,7 @@ function decode_ADD_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_ADD_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19495,8 +19251,7 @@ function decode_SUB_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_SUB_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19571,8 +19326,7 @@ function decode_ADD_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_ADD_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19647,8 +19401,7 @@ function decode_SUB_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_SUB_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19723,8 +19476,7 @@ function decode_ADD_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_ADD_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19799,8 +19551,7 @@ function decode_SUB_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_SUB_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19875,8 +19626,7 @@ function decode_ADD_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_ADD_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19951,8 +19701,7 @@ function decode_SUB_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_SUB_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20035,8 +19784,7 @@ function decode_UDOT_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20119,8 +19867,7 @@ function decode_SDOT_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20200,8 +19947,7 @@ function decode_USDOT_ZA_ZZW_S2x2 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_USDOT_ZA_ZZW_S2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20282,8 +20028,7 @@ function decode_UDOT_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20366,8 +20111,7 @@ function decode_SDOT_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20447,8 +20191,7 @@ function decode_USDOT_ZA_ZZV_S2x1 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_USDOT_ZA_ZZV_S2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20527,8 +20270,7 @@ function decode_SUDOT_ZA_ZZV_S2x1 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SUDOT_ZA_ZZV_S2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20610,8 +20352,7 @@ function decode_UDOT_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20694,8 +20435,7 @@ function decode_SDOT_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20775,8 +20515,7 @@ function decode_USDOT_ZA_ZZW_S4x4 (Zm, Rv, Zn, off3) = {
       },
       2048 => {
           execute_USDOT_ZA_ZZW_S4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20857,8 +20596,7 @@ function decode_UDOT_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20941,8 +20679,7 @@ function decode_SDOT_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21022,8 +20759,7 @@ function decode_USDOT_ZA_ZZV_S4x1 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_USDOT_ZA_ZZV_S4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21102,8 +20838,7 @@ function decode_SUDOT_ZA_ZZV_S4x1 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SUDOT_ZA_ZZV_S4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21186,8 +20921,7 @@ function decode_UDOT_ZA_ZZi_S2xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21271,8 +21005,7 @@ function decode_SDOT_ZA_ZZi_S2xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21356,8 +21089,7 @@ function decode_USDOT_ZA_ZZi_S2xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_USDOT_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21441,8 +21173,7 @@ function decode_SUDOT_ZA_ZZi_S2xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_SUDOT_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21526,8 +21257,7 @@ function decode_UDOT_ZA_ZZi_D2xi (Zm, Rv, i1, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA_ZZi_D2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21611,8 +21341,7 @@ function decode_SDOT_ZA_ZZi_D2xi (Zm, Rv, i1, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA_ZZi_D2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21696,8 +21425,7 @@ function decode_UDOT_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21781,8 +21509,7 @@ function decode_SDOT_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21866,8 +21593,7 @@ function decode_USDOT_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_USDOT_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -21951,8 +21677,7 @@ function decode_SUDOT_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_SUDOT_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22036,8 +21761,7 @@ function decode_UDOT_ZA_ZZi_D4xi (Zm, Rv, i1, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA_ZZi_D4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22121,8 +21845,7 @@ function decode_SDOT_ZA_ZZi_D4xi (Zm, Rv, i1, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA_ZZi_D4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22205,8 +21928,7 @@ function decode_UVDOT_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_UVDOT_ZA_ZZi_S4xi(2048, esize, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22289,8 +22011,7 @@ function decode_SVDOT_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_SVDOT_ZA_ZZi_S4xi(2048, esize, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22373,8 +22094,7 @@ function decode_USVDOT_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_USVDOT_ZA_ZZi_S4xi(2048, esize, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22457,8 +22177,7 @@ function decode_SUVDOT_ZA_ZZi_S4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_SUVDOT_ZA_ZZi_S4xi(2048, esize, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22541,8 +22260,7 @@ function decode_UVDOT_ZA_ZZi_D4xi (Zm, Rv, i1, Zn, U, off3) = {
       },
       2048 => {
           execute_UVDOT_ZA_ZZi_D4xi(2048, esize, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22625,8 +22343,7 @@ function decode_SVDOT_ZA_ZZi_D4xi (Zm, Rv, i1, Zn, U, off3) = {
       },
       2048 => {
           execute_SVDOT_ZA_ZZi_D4xi(2048, esize, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22706,8 +22423,7 @@ function decode_UDOT_ZA32_ZZW_2x2 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA32_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22786,8 +22502,7 @@ function decode_SDOT_ZA32_ZZW_2x2 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA32_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22866,8 +22581,7 @@ function decode_UDOT_ZA32_ZZV_2x1 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA32_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22946,8 +22660,7 @@ function decode_SDOT_ZA32_ZZV_2x1 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA32_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23026,8 +22739,7 @@ function decode_UDOT_ZA32_ZZW_4x4 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA32_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23106,8 +22818,7 @@ function decode_SDOT_ZA32_ZZW_4x4 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA32_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23186,8 +22897,7 @@ function decode_UDOT_ZA32_ZZV_4x1 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA32_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23266,8 +22976,7 @@ function decode_SDOT_ZA32_ZZV_4x1 (Zm, Rv, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA32_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23350,8 +23059,7 @@ function decode_UDOT_ZA32_ZZi_2xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA32_ZZi_2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23435,8 +23143,7 @@ function decode_SDOT_ZA32_ZZi_2xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA32_ZZi_2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23520,8 +23227,7 @@ function decode_UDOT_ZA32_ZZi_4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_UDOT_ZA32_ZZi_4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23605,8 +23311,7 @@ function decode_SDOT_ZA32_ZZi_4xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_SDOT_ZA32_ZZi_4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23689,8 +23394,7 @@ function decode_UVDOT_ZA32_ZZi_2xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_UVDOT_ZA32_ZZi_2xi(2048, esize, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23773,8 +23477,7 @@ function decode_SVDOT_ZA32_ZZi_2xi (Zm, Rv, i2, Zn, U, off3) = {
       },
       2048 => {
           execute_SVDOT_ZA32_ZZi_2xi(2048, esize, index, m, n, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23854,8 +23557,7 @@ function decode_UMLALL_ZA_ZZV_1 (sz, Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZV_1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23936,8 +23638,7 @@ function decode_UMLSLL_ZA_ZZV_1 (sz, Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZV_1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24018,8 +23719,7 @@ function decode_SMLALL_ZA_ZZV_1 (sz, Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZV_1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24100,8 +23800,7 @@ function decode_SMLSLL_ZA_ZZV_1 (sz, Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZV_1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24179,8 +23878,7 @@ function decode_USMLALL_ZA_ZZV_S (sz, Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_USMLALL_ZA_ZZV_S(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24261,8 +23959,7 @@ function decode_UMLALL_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24343,8 +24040,7 @@ function decode_UMLSLL_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24425,8 +24121,7 @@ function decode_SMLALL_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24507,8 +24202,7 @@ function decode_SMLSLL_ZA_ZZW_2x2 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24586,8 +24280,7 @@ function decode_USMLALL_ZA_ZZW_S2x2 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_USMLALL_ZA_ZZW_S2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24668,8 +24361,7 @@ function decode_UMLALL_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24750,8 +24442,7 @@ function decode_UMLSLL_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24832,8 +24523,7 @@ function decode_SMLALL_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24914,8 +24604,7 @@ function decode_SMLSLL_ZA_ZZV_2x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24993,8 +24682,7 @@ function decode_USMLALL_ZA_ZZV_S2x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_USMLALL_ZA_ZZV_S2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25072,8 +24760,7 @@ function decode_SUMLALL_ZA_ZZV_S2x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SUMLALL_ZA_ZZV_S2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25154,8 +24841,7 @@ function decode_UMLALL_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25236,8 +24922,7 @@ function decode_UMLSLL_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25318,8 +25003,7 @@ function decode_SMLALL_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25400,8 +25084,7 @@ function decode_SMLSLL_ZA_ZZW_4x4 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25479,8 +25162,7 @@ function decode_USMLALL_ZA_ZZW_S4x4 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_USMLALL_ZA_ZZW_S4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25561,8 +25243,7 @@ function decode_UMLALL_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25643,8 +25324,7 @@ function decode_UMLSLL_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25725,8 +25405,7 @@ function decode_SMLALL_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25807,8 +25486,7 @@ function decode_SMLSLL_ZA_ZZV_4x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25886,8 +25564,7 @@ function decode_USMLALL_ZA_ZZV_S4x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_USMLALL_ZA_ZZV_S4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25965,8 +25642,7 @@ function decode_SUMLALL_ZA_ZZV_S4x1 (sz, Zm, Rv, Zn, U, S, o1) = {
       },
       2048 => {
           execute_SUMLALL_ZA_ZZV_S4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26048,8 +25724,7 @@ function decode_UMLALL_ZA_ZZi_S (Zm, i4h, Rv, i4l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZi_S(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26132,8 +25807,7 @@ function decode_UMLSLL_ZA_ZZi_S (Zm, i4h, Rv, i4l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZi_S(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26216,8 +25890,7 @@ function decode_SMLALL_ZA_ZZi_S (Zm, i4h, Rv, i4l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZi_S(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26300,8 +25973,7 @@ function decode_SMLSLL_ZA_ZZi_S (Zm, i4h, Rv, i4l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZi_S(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26384,8 +26056,7 @@ function decode_USMLALL_ZA_ZZi_S (Zm, i4h, Rv, i4l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_USMLALL_ZA_ZZi_S(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26468,8 +26139,7 @@ function decode_SUMLALL_ZA_ZZi_S (Zm, i4h, Rv, i4l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SUMLALL_ZA_ZZi_S(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26552,8 +26222,7 @@ function decode_UMLALL_ZA_ZZi_D (Zm, i3h, Rv, i3l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZi_D(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26636,8 +26305,7 @@ function decode_UMLSLL_ZA_ZZi_D (Zm, i3h, Rv, i3l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZi_D(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26720,8 +26388,7 @@ function decode_SMLALL_ZA_ZZi_D (Zm, i3h, Rv, i3l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZi_D(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26804,8 +26471,7 @@ function decode_SMLSLL_ZA_ZZi_D (Zm, i3h, Rv, i3l, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZi_D(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26888,8 +26554,7 @@ function decode_UMLALL_ZA_ZZi_S2xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26972,8 +26637,7 @@ function decode_UMLSLL_ZA_ZZi_S2xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27056,8 +26720,7 @@ function decode_SMLALL_ZA_ZZi_S2xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27140,8 +26803,7 @@ function decode_SMLSLL_ZA_ZZi_S2xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27224,8 +26886,7 @@ function decode_USMLALL_ZA_ZZi_S2xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_USMLALL_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27308,8 +26969,7 @@ function decode_SUMLALL_ZA_ZZi_S2xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_SUMLALL_ZA_ZZi_S2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27392,8 +27052,7 @@ function decode_UMLALL_ZA_ZZi_D2xi (Zm, Rv, i3h, Zn, U, S, i3l, o1) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZi_D2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27476,8 +27135,7 @@ function decode_UMLSLL_ZA_ZZi_D2xi (Zm, Rv, i3h, Zn, U, S, i3l, o1) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZi_D2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27560,8 +27218,7 @@ function decode_SMLALL_ZA_ZZi_D2xi (Zm, Rv, i3h, Zn, U, S, i3l, o1) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZi_D2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27644,8 +27301,7 @@ function decode_SMLSLL_ZA_ZZi_D2xi (Zm, Rv, i3h, Zn, U, S, i3l, o1) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZi_D2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27728,8 +27384,7 @@ function decode_UMLALL_ZA_ZZi_S4xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27812,8 +27467,7 @@ function decode_UMLSLL_ZA_ZZi_S4xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27896,8 +27550,7 @@ function decode_SMLALL_ZA_ZZi_S4xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27980,8 +27633,7 @@ function decode_SMLSLL_ZA_ZZi_S4xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28064,8 +27716,7 @@ function decode_USMLALL_ZA_ZZi_S4xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_USMLALL_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28148,8 +27799,7 @@ function decode_SUMLALL_ZA_ZZi_S4xi (Zm, Rv, i4h, Zn, U, S, i4l, o1) = {
       },
       2048 => {
           execute_SUMLALL_ZA_ZZi_S4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28232,8 +27882,7 @@ function decode_UMLALL_ZA_ZZi_D4xi (Zm, Rv, i3h, Zn, U, S, i3l, o1) = {
       },
       2048 => {
           execute_UMLALL_ZA_ZZi_D4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28316,8 +27965,7 @@ function decode_UMLSLL_ZA_ZZi_D4xi (Zm, Rv, i3h, Zn, U, S, i3l, o1) = {
       },
       2048 => {
           execute_UMLSLL_ZA_ZZi_D4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28400,8 +28048,7 @@ function decode_SMLALL_ZA_ZZi_D4xi (Zm, Rv, i3h, Zn, U, S, i3l, o1) = {
       },
       2048 => {
           execute_SMLALL_ZA_ZZi_D4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28484,8 +28131,7 @@ function decode_SMLSLL_ZA_ZZi_D4xi (Zm, Rv, i3h, Zn, U, S, i3l, o1) = {
       },
       2048 => {
           execute_SMLSLL_ZA_ZZi_D4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28564,8 +28210,7 @@ function decode_UMLAL_ZA_ZZV_1 (Zm, Rv, Zn, U, S, off3) = {
       },
       2048 => {
           execute_UMLAL_ZA_ZZV_1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28642,8 +28287,7 @@ function decode_UMLSL_ZA_ZZV_1 (Zm, Rv, Zn, U, S, off3) = {
       },
       2048 => {
           execute_UMLSL_ZA_ZZV_1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28720,8 +28364,7 @@ function decode_SMLAL_ZA_ZZV_1 (Zm, Rv, Zn, U, S, off3) = {
       },
       2048 => {
           execute_SMLAL_ZA_ZZV_1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28798,8 +28441,7 @@ function decode_SMLSL_ZA_ZZV_1 (Zm, Rv, Zn, U, S, off3) = {
       },
       2048 => {
           execute_SMLSL_ZA_ZZV_1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28876,8 +28518,7 @@ function decode_UMLAL_ZA_ZZW_2x2 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLAL_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28954,8 +28595,7 @@ function decode_UMLSL_ZA_ZZW_2x2 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLSL_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29032,8 +28672,7 @@ function decode_SMLAL_ZA_ZZW_2x2 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLAL_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29110,8 +28749,7 @@ function decode_SMLSL_ZA_ZZW_2x2 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLSL_ZA_ZZW_2x2(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29188,8 +28826,7 @@ function decode_UMLAL_ZA_ZZV_2x1 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLAL_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29266,8 +28903,7 @@ function decode_UMLSL_ZA_ZZV_2x1 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLSL_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29344,8 +28980,7 @@ function decode_SMLAL_ZA_ZZV_2x1 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLAL_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29422,8 +29057,7 @@ function decode_SMLSL_ZA_ZZV_2x1 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLSL_ZA_ZZV_2x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29500,8 +29134,7 @@ function decode_UMLAL_ZA_ZZW_4x4 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLAL_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29578,8 +29211,7 @@ function decode_UMLSL_ZA_ZZW_4x4 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLSL_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29656,8 +29288,7 @@ function decode_SMLAL_ZA_ZZW_4x4 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLAL_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29734,8 +29365,7 @@ function decode_SMLSL_ZA_ZZW_4x4 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLSL_ZA_ZZW_4x4(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29812,8 +29442,7 @@ function decode_UMLAL_ZA_ZZV_4x1 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLAL_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29890,8 +29519,7 @@ function decode_UMLSL_ZA_ZZV_4x1 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_UMLSL_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29968,8 +29596,7 @@ function decode_SMLAL_ZA_ZZV_4x1 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLAL_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30046,8 +29673,7 @@ function decode_SMLSL_ZA_ZZV_4x1 (Zm, Rv, Zn, U, S, off2) = {
       },
       2048 => {
           execute_SMLSL_ZA_ZZV_4x1(2048, esize, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30128,8 +29754,7 @@ function decode_UMLAL_ZA_ZZi_1 (Zm, i3h, Rv, i3l, Zn, U, S, off3) = {
       },
       2048 => {
           execute_UMLAL_ZA_ZZi_1(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30212,8 +29837,7 @@ function decode_UMLSL_ZA_ZZi_1 (Zm, i3h, Rv, i3l, Zn, U, S, off3) = {
       },
       2048 => {
           execute_UMLSL_ZA_ZZi_1(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30296,8 +29920,7 @@ function decode_SMLAL_ZA_ZZi_1 (Zm, i3h, Rv, i3l, Zn, U, S, off3) = {
       },
       2048 => {
           execute_SMLAL_ZA_ZZi_1(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30380,8 +30003,7 @@ function decode_SMLSL_ZA_ZZi_1 (Zm, i3h, Rv, i3l, Zn, U, S, off3) = {
       },
       2048 => {
           execute_SMLSL_ZA_ZZi_1(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30464,8 +30086,7 @@ function decode_UMLAL_ZA_ZZi_2xi (Zm, Rv, i3h, Zn, U, S, i3l, off2) = {
       },
       2048 => {
           execute_UMLAL_ZA_ZZi_2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30548,8 +30169,7 @@ function decode_UMLSL_ZA_ZZi_2xi (Zm, Rv, i3h, Zn, U, S, i3l, off2) = {
       },
       2048 => {
           execute_UMLSL_ZA_ZZi_2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30632,8 +30252,7 @@ function decode_SMLAL_ZA_ZZi_2xi (Zm, Rv, i3h, Zn, U, S, i3l, off2) = {
       },
       2048 => {
           execute_SMLAL_ZA_ZZi_2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30716,8 +30335,7 @@ function decode_SMLSL_ZA_ZZi_2xi (Zm, Rv, i3h, Zn, U, S, i3l, off2) = {
       },
       2048 => {
           execute_SMLSL_ZA_ZZi_2xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30800,8 +30418,7 @@ function decode_UMLAL_ZA_ZZi_4xi (Zm, Rv, i3h, Zn, U, S, i3l, off2) = {
       },
       2048 => {
           execute_UMLAL_ZA_ZZi_4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30884,8 +30501,7 @@ function decode_UMLSL_ZA_ZZi_4xi (Zm, Rv, i3h, Zn, U, S, i3l, off2) = {
       },
       2048 => {
           execute_UMLSL_ZA_ZZi_4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30968,8 +30584,7 @@ function decode_SMLAL_ZA_ZZi_4xi (Zm, Rv, i3h, Zn, U, S, i3l, off2) = {
       },
       2048 => {
           execute_SMLAL_ZA_ZZi_4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31052,8 +30667,7 @@ function decode_SMLSL_ZA_ZZi_4xi (Zm, Rv, i3h, Zn, U, S, i3l, off2) = {
       },
       2048 => {
           execute_SMLSL_ZA_ZZi_4xi(2048, esize, index, m, n, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31121,8 +30735,7 @@ function decode_UMAX_MZ_ZZW_2x2 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_UMAX_MZ_ZZW_2x2(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31186,8 +30799,7 @@ function decode_SMAX_MZ_ZZW_2x2 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SMAX_MZ_ZZW_2x2(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31251,8 +30863,7 @@ function decode_UMAX_MZ_ZZV_2x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_UMAX_MZ_ZZV_2x1(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31316,8 +30927,7 @@ function decode_SMAX_MZ_ZZV_2x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SMAX_MZ_ZZV_2x1(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31381,8 +30991,7 @@ function decode_UMAX_MZ_ZZW_4x4 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_UMAX_MZ_ZZW_4x4(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31446,8 +31055,7 @@ function decode_SMAX_MZ_ZZW_4x4 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SMAX_MZ_ZZW_4x4(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31511,8 +31119,7 @@ function decode_UMAX_MZ_ZZV_4x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_UMAX_MZ_ZZV_4x1(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31576,8 +31183,7 @@ function decode_SMAX_MZ_ZZV_4x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SMAX_MZ_ZZV_4x1(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31641,8 +31247,7 @@ function decode_UMIN_MZ_ZZW_2x2 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_UMIN_MZ_ZZW_2x2(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31706,8 +31311,7 @@ function decode_SMIN_MZ_ZZW_2x2 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SMIN_MZ_ZZW_2x2(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31771,8 +31375,7 @@ function decode_UMIN_MZ_ZZV_2x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_UMIN_MZ_ZZV_2x1(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31836,8 +31439,7 @@ function decode_SMIN_MZ_ZZV_2x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SMIN_MZ_ZZV_2x1(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31901,8 +31503,7 @@ function decode_UMIN_MZ_ZZW_4x4 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_UMIN_MZ_ZZW_4x4(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31966,8 +31567,7 @@ function decode_SMIN_MZ_ZZW_4x4 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SMIN_MZ_ZZW_4x4(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32031,8 +31631,7 @@ function decode_UMIN_MZ_ZZV_4x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_UMIN_MZ_ZZV_4x1(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32096,8 +31695,7 @@ function decode_SMIN_MZ_ZZV_4x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SMIN_MZ_ZZV_4x1(2048, dn, esize, m, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32167,8 +31765,7 @@ function decode_URSHL_MZ_ZZW_2x2 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_URSHL_MZ_ZZW_2x2(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32238,8 +31835,7 @@ function decode_SRSHL_MZ_ZZW_2x2 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SRSHL_MZ_ZZW_2x2(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32309,8 +31905,7 @@ function decode_URSHL_MZ_ZZV_2x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_URSHL_MZ_ZZV_2x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32380,8 +31975,7 @@ function decode_SRSHL_MZ_ZZV_2x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SRSHL_MZ_ZZV_2x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32451,8 +32045,7 @@ function decode_URSHL_MZ_ZZW_4x4 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_URSHL_MZ_ZZW_4x4(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32522,8 +32115,7 @@ function decode_SRSHL_MZ_ZZW_4x4 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SRSHL_MZ_ZZW_4x4(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32593,8 +32185,7 @@ function decode_URSHL_MZ_ZZV_4x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_URSHL_MZ_ZZV_4x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32664,8 +32255,7 @@ function decode_SRSHL_MZ_ZZV_4x1 (size, Zm, Zdn, U) = {
       },
       2048 => {
           execute_SRSHL_MZ_ZZV_4x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32728,8 +32318,7 @@ function decode_SQDMULH_MZ_ZZW_2x2 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_SQDMULH_MZ_ZZW_2x2(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32791,8 +32380,7 @@ function decode_SQDMULH_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_SQDMULH_MZ_ZZV_2x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32854,8 +32442,7 @@ function decode_SQDMULH_MZ_ZZW_4x4 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_SQDMULH_MZ_ZZW_4x4(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32917,8 +32504,7 @@ function decode_SQDMULH_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_SQDMULH_MZ_ZZV_4x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32979,8 +32565,7 @@ function decode_ADD_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_ADD_MZ_ZZV_2x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33041,8 +32626,7 @@ function decode_ADD_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_ADD_MZ_ZZV_4x1(2048, dn, esize, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33107,8 +32691,7 @@ function decode_UCLAMP_MZ_ZZ_2 (size, Zm, Zn, Zd, U) = {
       },
       2048 => {
           execute_UCLAMP_MZ_ZZ_2(2048, d, esize, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33175,8 +32758,7 @@ function decode_SCLAMP_MZ_ZZ_2 (size, Zm, Zn, Zd, U) = {
       },
       2048 => {
           execute_SCLAMP_MZ_ZZ_2(2048, d, esize, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33243,8 +32825,7 @@ function decode_UCLAMP_MZ_ZZ_4 (size, Zm, Zn, Zd, U) = {
       },
       2048 => {
           execute_UCLAMP_MZ_ZZ_4(2048, d, esize, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33311,8 +32892,7 @@ function decode_SCLAMP_MZ_ZZ_4 (size, Zm, Zn, Zd, U) = {
       },
       2048 => {
           execute_SCLAMP_MZ_ZZ_4(2048, d, esize, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33381,8 +32961,7 @@ function decode_UUNPK_MZ_Z_2 (size, Zn, Zd, U) = {
       },
       2048 => {
           execute_UUNPK_MZ_Z_2(2048, d, esize, n, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33450,8 +33029,7 @@ function decode_SUNPK_MZ_Z_2 (size, Zn, Zd, U) = {
       },
       2048 => {
           execute_SUNPK_MZ_Z_2(2048, d, esize, n, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33519,8 +33097,7 @@ function decode_UUNPK_MZ_Z_4 (size, Zn, Zd, U) = {
       },
       2048 => {
           execute_UUNPK_MZ_Z_4(2048, d, esize, n, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33588,8 +33165,7 @@ function decode_SUNPK_MZ_Z_4 (size, Zn, Zd, U) = {
       },
       2048 => {
           execute_SUNPK_MZ_Z_4(2048, d, esize, n, nreg, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33648,8 +33224,7 @@ function decode_SQRSHR_Z_MZ2__ (imm4, Zn, U, Zd) = {
       },
       2048 => {
           execute_SQRSHR_Z_MZ2__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33708,8 +33283,7 @@ function decode_UQRSHR_Z_MZ2__ (imm4, Zn, U, Zd) = {
       },
       2048 => {
           execute_UQRSHR_Z_MZ2__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33768,8 +33342,7 @@ function decode_SQRSHRU_Z_MZ2__ (imm4, Zn, U, Zd) = {
       },
       2048 => {
           execute_SQRSHRU_Z_MZ2__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33840,8 +33413,7 @@ function decode_SQRSHRN_Z_MZ4__ (tsize, imm5, N, Zn, U, Zd) = {
       },
       2048 => {
           execute_SQRSHRN_Z_MZ4__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33914,8 +33486,7 @@ function decode_UQRSHRN_Z_MZ4__ (tsize, imm5, N, Zn, U, Zd) = {
       },
       2048 => {
           execute_UQRSHRN_Z_MZ4__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33988,8 +33559,7 @@ function decode_SQRSHRUN_Z_MZ4__ (tsize, imm5, N, Zn, U, Zd) = {
       },
       2048 => {
           execute_SQRSHRUN_Z_MZ4__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34062,8 +33632,7 @@ function decode_SQRSHR_Z_MZ4__ (tsize, imm5, N, Zn, U, Zd) = {
       },
       2048 => {
           execute_SQRSHR_Z_MZ4__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34136,8 +33705,7 @@ function decode_UQRSHR_Z_MZ4__ (tsize, imm5, N, Zn, U, Zd) = {
       },
       2048 => {
           execute_UQRSHR_Z_MZ4__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34210,8 +33778,7 @@ function decode_SQRSHRU_Z_MZ4__ (tsize, imm5, N, Zn, U, Zd) = {
       },
       2048 => {
           execute_SQRSHRU_Z_MZ4__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34270,8 +33837,7 @@ function decode_SQCVT_Z_MZ2__ (Zn, U, Zd) = {
       },
       2048 => {
           execute_SQCVT_Z_MZ2__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34327,8 +33893,7 @@ function decode_UQCVT_Z_MZ2__ (Zn, U, Zd) = {
       },
       2048 => {
           execute_UQCVT_Z_MZ2__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34384,8 +33949,7 @@ function decode_SQCVTU_Z_MZ2__ (Zn, U, Zd) = {
       },
       2048 => {
           execute_SQCVTU_Z_MZ2__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34446,8 +34010,7 @@ function decode_SQCVTN_Z_MZ4__ (sz, Zn, N, U, Zd) = {
       2048 => {
           assert(constraint((0 <= 'n & 'n <= 31 & 'esize in {8, 16} & 0 <= 'd & 'd <= 31 & is_VL(2048))));
           execute_SQCVTN_Z_MZ4__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34510,8 +34073,7 @@ function decode_UQCVTN_Z_MZ4__ (sz, Zn, N, U, Zd) = {
       2048 => {
           assert(constraint((0 <= 'n & 'n <= 31 & 'esize in {8, 16} & 0 <= 'd & 'd <= 31 & is_VL(2048))));
           execute_UQCVTN_Z_MZ4__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34574,8 +34136,7 @@ function decode_SQCVTUN_Z_MZ4__ (sz, Zn, N, U, Zd) = {
       2048 => {
           assert(constraint((0 <= 'n & 'n <= 31 & 'esize in {8, 16} & 0 <= 'd & 'd <= 31 & is_VL(2048))));
           execute_SQCVTUN_Z_MZ4__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34638,8 +34199,7 @@ function decode_SQCVT_Z_MZ4__ (sz, Zn, N, U, Zd) = {
       2048 => {
           assert(constraint((0 <= 'n & 'n <= 31 & 'esize in {8, 16} & 0 <= 'd & 'd <= 31 & is_VL(2048))));
           execute_SQCVT_Z_MZ4__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34702,8 +34262,7 @@ function decode_UQCVT_Z_MZ4__ (sz, Zn, N, U, Zd) = {
       2048 => {
           assert(constraint((0 <= 'n & 'n <= 31 & 'esize in {8, 16} & 0 <= 'd & 'd <= 31 & is_VL(2048))));
           execute_UQCVT_Z_MZ4__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34766,8 +34325,7 @@ function decode_SQCVTU_Z_MZ4__ (sz, Zn, N, U, Zd) = {
       2048 => {
           assert(constraint((0 <= 'n & 'n <= 31 & 'esize in {8, 16} & 0 <= 'd & 'd <= 31 & is_VL(2048))));
           execute_SQCVTU_Z_MZ4__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34831,8 +34389,7 @@ function decode_ZIP_MZ_ZZ_2 (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_ZIP_MZ_ZZ_2(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34897,8 +34454,7 @@ function decode_UZP_MZ_ZZ_2 (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_UZP_MZ_ZZ_2(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34961,8 +34517,7 @@ function decode_ZIP_MZ_ZZ_2Q (Zm, Zn, Zd) = {
       },
       2048 => {
           execute_ZIP_MZ_ZZ_2Q(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35026,8 +34581,7 @@ function decode_UZP_MZ_ZZ_2Q (Zm, Zn, Zd) = {
       },
       2048 => {
           execute_UZP_MZ_ZZ_2Q(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35092,8 +34646,7 @@ function decode_ZIP_MZ_Z_4 (size, Zn, Zd) = {
       },
       2048 => {
           execute_ZIP_MZ_Z_4(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35161,8 +34714,7 @@ function decode_UZP_MZ_Z_4 (size, Zn, Zd) = {
       },
       2048 => {
           execute_UZP_MZ_Z_4(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35227,8 +34779,7 @@ function decode_ZIP_MZ_Z_4Q (Zn, Zd) = {
       },
       2048 => {
           execute_ZIP_MZ_Z_4Q(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35295,8 +34846,7 @@ function decode_UZP_MZ_Z_4Q (Zn, Zd) = {
       },
       2048 => {
           execute_UZP_MZ_Z_4Q(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35363,8 +34913,7 @@ function decode_SEL_MZ_P_ZZ_2 (size, Zm, PNg, Zn, Zd) = {
       },
       2048 => {
           execute_SEL_MZ_P_ZZ_2(2048, d, esize, g, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35434,8 +34983,7 @@ function decode_SEL_MZ_P_ZZ_4 (size, Zm, PNg, Zn, Zd) = {
       },
       2048 => {
           execute_SEL_MZ_P_ZZ_4(2048, d, esize, g, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35513,8 +35061,7 @@ function decode_BMOPA_ZA_PP_ZZ_32 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_BMOPA_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35593,8 +35140,7 @@ function decode_BMOPS_ZA_PP_ZZ_32 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_BMOPS_ZA_PP_ZZ_32(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35674,8 +35220,7 @@ function decode_SMOPA_ZA32_PP_ZZ_16 (u0, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SMOPA_ZA32_PP_ZZ_16(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35756,8 +35301,7 @@ function decode_UMOPA_ZA32_PP_ZZ_16 (u0, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_UMOPA_ZA32_PP_ZZ_16(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35838,8 +35382,7 @@ function decode_SMOPS_ZA32_PP_ZZ_16 (u0, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_SMOPS_ZA32_PP_ZZ_16(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35920,8 +35463,7 @@ function decode_UMOPS_ZA32_PP_ZZ_16 (u0, Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_UMOPS_ZA32_PP_ZZ_16(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35993,8 +35535,7 @@ function decode_LUTI2_Z_ZTZ__ (i4, size, Zn, Zd) = {
       },
       2048 => {
           execute_LUTI2_Z_ZTZ__(2048, d, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36063,8 +35604,7 @@ function decode_LUTI4_Z_ZTZ__ (i3, size, Zn, Zd) = {
       },
       2048 => {
           execute_LUTI4_Z_ZTZ__(2048, d, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36136,8 +35676,7 @@ function decode_LUTI2_MZ2_ZTZ_1 (i3, size, Zn, Zd) = {
       },
       2048 => {
           execute_LUTI2_MZ2_ZTZ_1(2048, d, dstride, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36209,8 +35748,7 @@ function decode_LUTI4_MZ2_ZTZ_1 (i2, size, Zn, Zd) = {
       },
       2048 => {
           execute_LUTI4_MZ2_ZTZ_1(2048, d, dstride, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36282,8 +35820,7 @@ function decode_LUTI2_MZ4_ZTZ_1 (i2, size, Zn, Zd) = {
       },
       2048 => {
           execute_LUTI2_MZ4_ZTZ_1(2048, d, dstride, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36355,8 +35892,7 @@ function decode_LUTI4_MZ4_ZTZ_1 (i1, size, Zn, Zd) = {
       },
       2048 => {
           execute_LUTI4_MZ4_ZTZ_1(2048, d, dstride, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36581,8 +36117,7 @@ function decode_RDSVL_R_I__ (imm6, Rd) = {
       },
       2048 => {
           execute_RDSVL_R_I__(2048, d, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36635,8 +36170,7 @@ function decode_ADDSPL_R_RI__ (Rn, imm6, Rd) = {
       },
       2048 => {
           execute_ADDSPL_R_RI__(2048, d, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36690,8 +36224,7 @@ function decode_ADDSVL_R_RI__ (Rn, imm6, Rd) = {
       },
       2048 => {
           execute_ADDSVL_R_RI__(2048, d, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36748,8 +36281,7 @@ function decode_ZERO_ZA1_RI_2 (Rv, off3) = {
       },
       2048 => {
           execute_ZERO_ZA1_RI_2(2048, ngrp, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36805,8 +36337,7 @@ function decode_ZERO_ZA1_RI_4 (Rv, off3) = {
       },
       2048 => {
           execute_ZERO_ZA1_RI_4(2048, ngrp, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36866,8 +36397,7 @@ function decode_ZERO_ZA2_RI_1 (Rv, off3) = {
       },
       2048 => {
           execute_ZERO_ZA2_RI_1(2048, ngrp, nvec, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36927,8 +36457,7 @@ function decode_ZERO_ZA2_RI_2 (Rv, off2) = {
       },
       2048 => {
           execute_ZERO_ZA2_RI_2(2048, ngrp, nvec, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36988,8 +36517,7 @@ function decode_ZERO_ZA2_RI_4 (Rv, off2) = {
       },
       2048 => {
           execute_ZERO_ZA2_RI_4(2048, ngrp, nvec, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37049,8 +36577,7 @@ function decode_ZERO_ZA4_RI_1 (Rv, off2) = {
       },
       2048 => {
           execute_ZERO_ZA4_RI_1(2048, ngrp, nvec, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37110,8 +36637,7 @@ function decode_ZERO_ZA4_RI_2 (Rv, o1) = {
       },
       2048 => {
           execute_ZERO_ZA4_RI_2(2048, ngrp, nvec, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37171,8 +36697,7 @@ function decode_ZERO_ZA4_RI_4 (Rv, o1) = {
       },
       2048 => {
           execute_ZERO_ZA4_RI_4(2048, ngrp, nvec, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37242,8 +36767,7 @@ function decode_LUTI2_MZ2_ZTZ_8 (i3, size, Zn, D, Zd) = {
       },
       2048 => {
           execute_LUTI2_MZ2_ZTZ_8(2048, d, dstride, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37316,8 +36840,7 @@ function decode_LUTI4_MZ2_ZTZ_8 (i2, size, Zn, D, Zd) = {
       },
       2048 => {
           execute_LUTI4_MZ2_ZTZ_8(2048, d, dstride, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37390,8 +36913,7 @@ function decode_LUTI2_MZ4_ZTZ_4 (i2, size, Zn, D, Zd) = {
       },
       2048 => {
           execute_LUTI2_MZ4_ZTZ_4(2048, d, dstride, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37464,8 +36986,7 @@ function decode_LUTI4_MZ4_ZTZ_4 (i1, size, Zn, D, Zd) = {
       },
       2048 => {
           execute_LUTI4_MZ4_ZTZ_4(2048, d, dstride, esize, imm, isize, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37523,8 +37044,7 @@ function decode_MOVAZ_Z_RZA_B (size, Q, V, Rs, off4, Zd) = {
       },
       2048 => {
           execute_MOVAZ_Z_RZA_B(2048, d, esize, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37583,8 +37103,7 @@ function decode_MOVAZ_Z_RZA_H (size, Q, V, Rs, ZAn, off3, Zd) = {
       },
       2048 => {
           execute_MOVAZ_Z_RZA_H(2048, d, esize, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37644,8 +37163,7 @@ function decode_MOVAZ_Z_RZA_W (size, Q, V, Rs, ZAn, off2, Zd) = {
       },
       2048 => {
           execute_MOVAZ_Z_RZA_W(2048, d, esize, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37705,8 +37223,7 @@ function decode_MOVAZ_Z_RZA_D (size, Q, V, Rs, ZAn, o1, Zd) = {
       },
       2048 => {
           execute_MOVAZ_Z_RZA_D(2048, d, esize, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37766,8 +37283,7 @@ function decode_MOVAZ_Z_RZA_Q (size, Q, V, Rs, ZAn, Zd) = {
       },
       2048 => {
           execute_MOVAZ_Z_RZA_Q(2048, d, esize, n, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37831,8 +37347,7 @@ function decode_MOVAZ_MZ2_ZA_B1 (size, V, Rs, off3, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ2_ZA_B1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37895,8 +37410,7 @@ function decode_MOVAZ_MZ2_ZA_H1 (size, V, Rs, ZAn, off2, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ2_ZA_H1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37960,8 +37474,7 @@ function decode_MOVAZ_MZ2_ZA_W1 (size, V, Rs, ZAn, o1, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ2_ZA_W1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38025,8 +37538,7 @@ function decode_MOVAZ_MZ2_ZA_D1 (size, V, Rs, ZAn, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ2_ZA_D1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38089,8 +37601,7 @@ function decode_MOVAZ_MZ4_ZA_B1 (size, V, Rs, off2, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ4_ZA_B1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38153,8 +37664,7 @@ function decode_MOVAZ_MZ4_ZA_H1 (size, V, Rs, ZAn, o1, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ4_ZA_H1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38218,8 +37728,7 @@ function decode_MOVAZ_MZ4_ZA_W1 (size, V, Rs, ZAn, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ4_ZA_W1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38282,8 +37791,7 @@ function decode_MOVAZ_MZ4_ZA_D1 (size, V, Rs, ZAn, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ4_ZA_D1(2048, d, esize, n, nreg, offset, s, vertical)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38348,8 +37856,7 @@ function decode_MOVAZ_MZ_ZA2_1 (Rv, off3, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ_ZA2_1(2048, d, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38412,8 +37919,7 @@ function decode_MOVAZ_MZ_ZA4_1 (Rv, off3, Zd) = {
       },
       2048 => {
           execute_MOVAZ_MZ_ZA4_1(2048, d, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38487,8 +37993,7 @@ function decode_FMOPA_ZA_PP_ZZ_16 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_FMOPA_ZA_PP_ZZ_16(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38565,8 +38070,7 @@ function decode_FMOPS_ZA_PP_ZZ_16 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_FMOPS_ZA_PP_ZZ_16(2048, DIV(2048, esize) * DIV(2048, esize) * esize, a, b, da, esize, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38642,8 +38146,7 @@ function decode_BFMOPA_ZA_PP_ZZ_16 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_BFMOPA_ZA_PP_ZZ_16(2048, DIV(2048, 16) * DIV(2048, 16) * 16, a, b, da, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38719,8 +38222,7 @@ function decode_BFMOPS_ZA_PP_ZZ_16 (Zm, Pm, Pn, Zn, S, ZAda) = {
       },
       2048 => {
           execute_BFMOPS_ZA_PP_ZZ_16(2048, DIV(2048, 16) * DIV(2048, 16) * 16, a, b, da, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38794,8 +38296,7 @@ function decode_FADD_ZA_ZW_2x2_16 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_FADD_ZA_ZW_2x2_16(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38868,8 +38369,7 @@ function decode_FSUB_ZA_ZW_2x2_16 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_FSUB_ZA_ZW_2x2_16(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38941,8 +38441,7 @@ function decode_BFADD_ZA_ZW_2x2_16 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_BFADD_ZA_ZW_2x2_16(2048, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39014,8 +38513,7 @@ function decode_BFSUB_ZA_ZW_2x2_16 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_BFSUB_ZA_ZW_2x2_16(2048, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39088,8 +38586,7 @@ function decode_FADD_ZA_ZW_4x4_16 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_FADD_ZA_ZW_4x4_16(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39162,8 +38659,7 @@ function decode_FSUB_ZA_ZW_4x4_16 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_FSUB_ZA_ZW_4x4_16(2048, esize, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39235,8 +38731,7 @@ function decode_BFADD_ZA_ZW_4x4_16 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_BFADD_ZA_ZW_4x4_16(2048, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39308,8 +38803,7 @@ function decode_BFSUB_ZA_ZW_4x4_16 (sz, Rv, Zm, S, off3) = {
       },
       2048 => {
           execute_BFSUB_ZA_ZW_4x4_16(2048, m, nreg, offset, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39389,8 +38883,7 @@ function decode_FMLA_ZA_ZZW_2x2_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZW_2x2_16(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39471,8 +38964,7 @@ function decode_FMLS_ZA_ZZW_2x2_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZW_2x2_16(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39552,8 +39044,7 @@ function decode_BFMLA_ZA_ZZW_2x2_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLA_ZA_ZZW_2x2_16(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39633,8 +39124,7 @@ function decode_BFMLS_ZA_ZZW_2x2_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLS_ZA_ZZW_2x2_16(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39715,8 +39205,7 @@ function decode_FMLA_ZA_ZZV_2x1_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZV_2x1_16(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39797,8 +39286,7 @@ function decode_FMLS_ZA_ZZV_2x1_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZV_2x1_16(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39878,8 +39366,7 @@ function decode_BFMLA_ZA_ZZV_2x1_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLA_ZA_ZZV_2x1_16(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39959,8 +39446,7 @@ function decode_BFMLS_ZA_ZZV_2x1_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLS_ZA_ZZV_2x1_16(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40041,8 +39527,7 @@ function decode_FMLA_ZA_ZZW_4x4_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZW_4x4_16(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40123,8 +39608,7 @@ function decode_FMLS_ZA_ZZW_4x4_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZW_4x4_16(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40204,8 +39688,7 @@ function decode_BFMLA_ZA_ZZW_4x4_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLA_ZA_ZZW_4x4_16(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40285,8 +39768,7 @@ function decode_BFMLS_ZA_ZZW_4x4_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLS_ZA_ZZW_4x4_16(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40367,8 +39849,7 @@ function decode_FMLA_ZA_ZZV_4x1_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZV_4x1_16(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40449,8 +39930,7 @@ function decode_FMLS_ZA_ZZV_4x1_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZV_4x1_16(2048, esize, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40530,8 +40010,7 @@ function decode_BFMLA_ZA_ZZV_4x1_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLA_ZA_ZZV_4x1_16(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40611,8 +40090,7 @@ function decode_BFMLS_ZA_ZZV_4x1_16 (sz, Zm, Rv, Zn, S, off3) = {
       },
       2048 => {
           execute_BFMLS_ZA_ZZV_4x1_16(2048, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40697,8 +40175,7 @@ function decode_FMLA_ZA_ZZi_H2xi (Zm, Rv, i3h, Zn, S, i3l, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZi_H2xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40784,8 +40261,7 @@ function decode_FMLS_ZA_ZZi_H2xi (Zm, Rv, i3h, Zn, S, i3l, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZi_H2xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40871,8 +40347,7 @@ function decode_BFMLA_ZA_ZZi_H2xi (Zm, Rv, i3h, Zn, S, i3l, off3) = {
       },
       2048 => {
           execute_BFMLA_ZA_ZZi_H2xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40958,8 +40433,7 @@ function decode_BFMLS_ZA_ZZi_H2xi (Zm, Rv, i3h, Zn, S, i3l, off3) = {
       },
       2048 => {
           execute_BFMLS_ZA_ZZi_H2xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41045,8 +40519,7 @@ function decode_FMLA_ZA_ZZi_H4xi (Zm, Rv, i3h, Zn, S, i3l, off3) = {
       },
       2048 => {
           execute_FMLA_ZA_ZZi_H4xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41132,8 +40605,7 @@ function decode_FMLS_ZA_ZZi_H4xi (Zm, Rv, i3h, Zn, S, i3l, off3) = {
       },
       2048 => {
           execute_FMLS_ZA_ZZi_H4xi(2048, esize, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41219,8 +40691,7 @@ function decode_BFMLA_ZA_ZZi_H4xi (Zm, Rv, i3h, Zn, S, i3l, off3) = {
       },
       2048 => {
           execute_BFMLA_ZA_ZZi_H4xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41306,8 +40777,7 @@ function decode_BFMLS_ZA_ZZi_H4xi (Zm, Rv, i3h, Zn, S, i3l, off3) = {
       },
       2048 => {
           execute_BFMLS_ZA_ZZi_H4xi(2048, index, m, n, nreg, offset, sub_op, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41371,8 +40841,7 @@ function decode_BFMAX_MZ_ZZW_2x2 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAX_MZ_ZZW_2x2(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41432,8 +40901,7 @@ function decode_BFMAX_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAX_MZ_ZZV_2x1(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41493,8 +40961,7 @@ function decode_BFMIN_MZ_ZZW_2x2 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMIN_MZ_ZZW_2x2(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41554,8 +41021,7 @@ function decode_BFMIN_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMIN_MZ_ZZV_2x1(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41615,8 +41081,7 @@ function decode_BFMAX_MZ_ZZW_4x4 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAX_MZ_ZZW_4x4(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41676,8 +41141,7 @@ function decode_BFMAX_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAX_MZ_ZZV_4x1(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41737,8 +41201,7 @@ function decode_BFMIN_MZ_ZZW_4x4 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMIN_MZ_ZZW_4x4(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41798,8 +41261,7 @@ function decode_BFMIN_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMIN_MZ_ZZV_4x1(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41859,8 +41321,7 @@ function decode_BFMAXNM_MZ_ZZW_2x2 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAXNM_MZ_ZZW_2x2(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41920,8 +41381,7 @@ function decode_BFMAXNM_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAXNM_MZ_ZZV_2x1(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41981,8 +41441,7 @@ function decode_BFMINNM_MZ_ZZW_2x2 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMINNM_MZ_ZZW_2x2(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42042,8 +41501,7 @@ function decode_BFMINNM_MZ_ZZV_2x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMINNM_MZ_ZZV_2x1(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42103,8 +41561,7 @@ function decode_BFMAXNM_MZ_ZZW_4x4 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAXNM_MZ_ZZW_4x4(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42164,8 +41621,7 @@ function decode_BFMAXNM_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAXNM_MZ_ZZV_4x1(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42225,8 +41681,7 @@ function decode_BFMINNM_MZ_ZZW_4x4 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMINNM_MZ_ZZW_4x4(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42286,8 +41741,7 @@ function decode_BFMINNM_MZ_ZZV_4x1 (size, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMINNM_MZ_ZZV_4x1(2048, dn, m, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42342,8 +41796,7 @@ function decode_FCVT_MZ2_Z__ (Zn, Zd, L) = {
       },
       2048 => {
           execute_FCVT_MZ2_Z__(2048, d, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42402,8 +41855,7 @@ function decode_FCVTL_MZ2_Z__ (Zn, Zd, L) = {
       },
       2048 => {
           execute_FCVTL_MZ2_Z__(2048, d, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42466,8 +41918,7 @@ function decode_BFCLAMP_MZ_ZZ_2 (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BFCLAMP_MZ_ZZ_2(2048, d, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42531,8 +41982,7 @@ function decode_BFCLAMP_MZ_ZZ_4 (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BFCLAMP_MZ_ZZ_4(2048, d, m, n, nreg)
-      },
-      _ => ()
+      }
     }
 }
 

--- a/arm-v9.4-a/src/instrs64_sve.sail
+++ b/arm-v9.4-a/src/instrs64_sve.sail
@@ -97,8 +97,7 @@ function decode_FADD_Z_P_ZS__ (size, Pg, i1, Zdn) = {
       },
       2048 => {
           execute_FADD_Z_P_ZS__(2048, dn, esize, g, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -170,8 +169,7 @@ function decode_FSUB_Z_P_ZS__ (size, Pg, i1, Zdn) = {
       },
       2048 => {
           execute_FSUB_Z_P_ZS__(2048, dn, esize, g, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -243,8 +241,7 @@ function decode_FMUL_Z_P_ZS__ (size, Pg, i1, Zdn) = {
       },
       2048 => {
           execute_FMUL_Z_P_ZS__(2048, dn, esize, g, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -316,8 +313,7 @@ function decode_FSUBR_Z_P_ZS__ (size, Pg, i1, Zdn) = {
       },
       2048 => {
           execute_FSUBR_Z_P_ZS__(2048, dn, esize, g, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -386,8 +382,7 @@ function decode_FMAXNM_Z_P_ZS__ (size, Pg, i1, Zdn) = {
       },
       2048 => {
           execute_FMAXNM_Z_P_ZS__(2048, dn, esize, g, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -456,8 +451,7 @@ function decode_FMINNM_Z_P_ZS__ (size, Pg, i1, Zdn) = {
       },
       2048 => {
           execute_FMINNM_Z_P_ZS__(2048, dn, esize, g, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -526,8 +520,7 @@ function decode_FMAX_Z_P_ZS__ (size, Pg, i1, Zdn) = {
       },
       2048 => {
           execute_FMAX_Z_P_ZS__(2048, dn, esize, g, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -596,8 +589,7 @@ function decode_FMIN_Z_P_ZS__ (size, Pg, i1, Zdn) = {
       },
       2048 => {
           execute_FMIN_Z_P_ZS__(2048, dn, esize, g, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -655,7 +647,7 @@ function execute_FCMGE_P_P_Z0__ (VL, d, esize, g, n, op) = {
                   assert(constraint(('esize - 1 - 0 + 1 == 16 | 'esize - 1 - 0 + 1 == 32 | 'esize - 1 - 0 + 1 == 64)));
                   res = FPCompareGE(0[esize - 1 .. 0], element, FPCR_read())
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_FCMGE_P_P_Z0__")
             };
             let pbit : bits(1) = if res then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -696,8 +688,7 @@ function decode_FCMGE_P_P_Z0__ (size, eq, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_FCMGE_P_P_Z0__(2048, d, esize, g, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -758,7 +749,7 @@ function execute_FCMGT_P_P_Z0__ (VL, d, esize, g, n, op) = {
                   assert(constraint(('esize - 1 - 0 + 1 == 16 | 'esize - 1 - 0 + 1 == 32 | 'esize - 1 - 0 + 1 == 64)));
                   res = FPCompareGE(0[esize - 1 .. 0], element, FPCR_read())
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_FCMGT_P_P_Z0__")
             };
             let pbit : bits(1) = if res then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -799,8 +790,7 @@ function decode_FCMGT_P_P_Z0__ (size, eq, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_FCMGT_P_P_Z0__(2048, d, esize, g, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -861,7 +851,7 @@ function execute_FCMLT_P_P_Z0__ (VL, d, esize, g, n, op) = {
                   assert(constraint(('esize - 1 - 0 + 1 == 16 | 'esize - 1 - 0 + 1 == 32 | 'esize - 1 - 0 + 1 == 64)));
                   res = FPCompareGE(0[esize - 1 .. 0], element, FPCR_read())
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_FCMLT_P_P_Z0__")
             };
             let pbit : bits(1) = if res then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -902,8 +892,7 @@ function decode_FCMLT_P_P_Z0__ (size, eq, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_FCMLT_P_P_Z0__(2048, d, esize, g, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -964,7 +953,7 @@ function execute_FCMLE_P_P_Z0__ (VL, d, esize, g, n, op) = {
                   assert(constraint(('esize - 1 - 0 + 1 == 16 | 'esize - 1 - 0 + 1 == 32 | 'esize - 1 - 0 + 1 == 64)));
                   res = FPCompareGE(0[esize - 1 .. 0], element, FPCR_read())
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_FCMLE_P_P_Z0__")
             };
             let pbit : bits(1) = if res then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -1005,8 +994,7 @@ function decode_FCMLE_P_P_Z0__ (size, eq, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_FCMLE_P_P_Z0__(2048, d, esize, g, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1067,7 +1055,7 @@ function execute_FCMEQ_P_P_Z0__ (VL, d, esize, g, n, op) = {
                   assert(constraint(('esize - 1 - 0 + 1 == 16 | 'esize - 1 - 0 + 1 == 32 | 'esize - 1 - 0 + 1 == 64)));
                   res = FPCompareGE(0[esize - 1 .. 0], element, FPCR_read())
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_FCMEQ_P_P_Z0__")
             };
             let pbit : bits(1) = if res then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -1108,8 +1096,7 @@ function decode_FCMEQ_P_P_Z0__ (size, eq, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_FCMEQ_P_P_Z0__(2048, d, esize, g, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1170,7 +1157,7 @@ function execute_FCMNE_P_P_Z0__ (VL, d, esize, g, n, op) = {
                   assert(constraint(('esize - 1 - 0 + 1 == 16 | 'esize - 1 - 0 + 1 == 32 | 'esize - 1 - 0 + 1 == 64)));
                   res = FPCompareGE(0[esize - 1 .. 0], element, FPCR_read())
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_FCMNE_P_P_Z0__")
             };
             let pbit : bits(1) = if res then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -1211,8 +1198,7 @@ function decode_FCMNE_P_P_Z0__ (size, eq, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_FCMNE_P_P_Z0__(2048, d, esize, g, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1284,8 +1270,7 @@ function decode_FADDA_V_P_Z__ (size, Pg, Zm, Vdn) = {
       },
       2048 => {
           execute_FADDA_V_P_Z__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1354,8 +1339,7 @@ function decode_FCVTZU_Z_P_Z_D2X (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZU_Z_P_Z_D2X(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1424,8 +1408,7 @@ function decode_FCVTZU_Z_P_Z_D2W (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZU_Z_P_Z_D2W(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1494,8 +1477,7 @@ function decode_FCVTZU_Z_P_Z_S2W (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZU_Z_P_Z_S2W(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1564,8 +1546,7 @@ function decode_FCVTZU_Z_P_Z_S2X (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZU_Z_P_Z_S2X(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1634,8 +1615,7 @@ function decode_FCVTZS_Z_P_Z_D2X (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZS_Z_P_Z_D2X(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1704,8 +1684,7 @@ function decode_FCVTZS_Z_P_Z_D2W (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZS_Z_P_Z_D2W(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1774,8 +1753,7 @@ function decode_FCVTZS_Z_P_Z_S2W (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZS_Z_P_Z_S2W(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1844,8 +1822,7 @@ function decode_FCVTZS_Z_P_Z_S2X (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZS_Z_P_Z_S2X(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1914,8 +1891,7 @@ function decode_FCVTZS_Z_P_Z_FP162H (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZS_Z_P_Z_FP162H(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -1984,8 +1960,7 @@ function decode_FCVTZS_Z_P_Z_FP162W (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZS_Z_P_Z_FP162W(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2054,8 +2029,7 @@ function decode_FCVTZS_Z_P_Z_FP162X (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZS_Z_P_Z_FP162X(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2124,8 +2098,7 @@ function decode_FCVTZU_Z_P_Z_FP162H (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZU_Z_P_Z_FP162H(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2194,8 +2167,7 @@ function decode_FCVTZU_Z_P_Z_FP162W (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZU_Z_P_Z_FP162W(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2264,8 +2236,7 @@ function decode_FCVTZU_Z_P_Z_FP162X (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTZU_Z_P_Z_FP162X(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2334,8 +2305,7 @@ function decode_SCVTF_Z_P_Z_H2FP16 (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SCVTF_Z_P_Z_H2FP16(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2404,8 +2374,7 @@ function decode_SCVTF_Z_P_Z_W2FP16 (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SCVTF_Z_P_Z_W2FP16(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2474,8 +2443,7 @@ function decode_SCVTF_Z_P_Z_X2FP16 (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SCVTF_Z_P_Z_X2FP16(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2544,8 +2512,7 @@ function decode_UCVTF_Z_P_Z_H2FP16 (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UCVTF_Z_P_Z_H2FP16(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2614,8 +2581,7 @@ function decode_UCVTF_Z_P_Z_W2FP16 (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UCVTF_Z_P_Z_W2FP16(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2684,8 +2650,7 @@ function decode_UCVTF_Z_P_Z_X2FP16 (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UCVTF_Z_P_Z_X2FP16(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2752,8 +2717,7 @@ function decode_FCVT_Z_P_Z_D2S (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVT_Z_P_Z_D2S(2048, d, d_esize, esize, g, n, s_esize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2819,8 +2783,7 @@ function decode_FCVT_Z_P_Z_D2H (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVT_Z_P_Z_D2H(2048, d, d_esize, esize, g, n, s_esize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2886,8 +2849,7 @@ function decode_FCVT_Z_P_Z_S2D (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVT_Z_P_Z_S2D(2048, d, d_esize, esize, g, n, s_esize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -2953,8 +2915,7 @@ function decode_FCVT_Z_P_Z_H2D (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVT_Z_P_Z_H2D(2048, d, d_esize, esize, g, n, s_esize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3020,8 +2981,7 @@ function decode_FCVT_Z_P_Z_H2S (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVT_Z_P_Z_H2S(2048, d, d_esize, esize, g, n, s_esize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3087,8 +3047,7 @@ function decode_FCVT_Z_P_Z_S2H (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVT_Z_P_Z_S2H(2048, d, d_esize, esize, g, n, s_esize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3147,8 +3106,7 @@ function decode_FRECPE_Z_Z__ (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRECPE_Z_Z__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3207,8 +3165,7 @@ function decode_FRSQRTE_Z_Z__ (size, Zn, Zd) = {
       },
       2048 => {
           execute_FRSQRTE_Z_Z__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3275,8 +3232,7 @@ function decode_FRECPX_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FRECPX_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3344,8 +3300,7 @@ function decode_FSQRT_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FSQRT_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3415,8 +3370,7 @@ function decode_FRINTA_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTA_Z_P_Z__(2048, d, esize, exact, g, n, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3486,8 +3440,7 @@ function decode_FRINTI_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTI_Z_P_Z__(2048, d, esize, exact, g, n, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3557,8 +3510,7 @@ function decode_FRINTM_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTM_Z_P_Z__(2048, d, esize, exact, g, n, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3628,8 +3580,7 @@ function decode_FRINTN_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTN_Z_P_Z__(2048, d, esize, exact, g, n, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3699,8 +3650,7 @@ function decode_FRINTP_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTP_Z_P_Z__(2048, d, esize, exact, g, n, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3770,8 +3720,7 @@ function decode_FRINTX_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTX_Z_P_Z__(2048, d, esize, exact, g, n, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3841,8 +3790,7 @@ function decode_FRINTZ_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FRINTZ_Z_P_Z__(2048, d, esize, exact, g, n, rounding)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3911,8 +3859,7 @@ function decode_UCVTF_Z_P_Z_X2S (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UCVTF_Z_P_Z_X2S(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -3981,8 +3928,7 @@ function decode_UCVTF_Z_P_Z_X2D (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UCVTF_Z_P_Z_X2D(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4051,8 +3997,7 @@ function decode_UCVTF_Z_P_Z_W2S (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UCVTF_Z_P_Z_W2S(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4121,8 +4066,7 @@ function decode_UCVTF_Z_P_Z_W2D (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UCVTF_Z_P_Z_W2D(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4191,8 +4135,7 @@ function decode_SCVTF_Z_P_Z_X2S (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SCVTF_Z_P_Z_X2S(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4261,8 +4204,7 @@ function decode_SCVTF_Z_P_Z_X2D (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SCVTF_Z_P_Z_X2D(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4331,8 +4273,7 @@ function decode_SCVTF_Z_P_Z_W2S (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SCVTF_Z_P_Z_W2S(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4401,8 +4342,7 @@ function decode_SCVTF_Z_P_Z_W2D (int_U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SCVTF_Z_P_Z_W2D(2048, d, d_esize, esize, g, n, rounding, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4473,8 +4413,7 @@ function decode_FABD_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FABD_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4542,8 +4481,7 @@ function decode_FADD_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FADD_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4614,8 +4552,7 @@ function decode_FDIV_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FDIV_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4686,8 +4623,7 @@ function decode_FDIVR_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FDIVR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4755,8 +4691,7 @@ function decode_FMAXNM_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAXNM_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4824,8 +4759,7 @@ function decode_FMINNM_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMINNM_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4893,8 +4827,7 @@ function decode_FMAX_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAX_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -4962,8 +4895,7 @@ function decode_FMIN_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMIN_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5031,8 +4963,7 @@ function decode_FMUL_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMUL_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5103,8 +5034,7 @@ function decode_FMULX_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMULX_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5175,8 +5105,7 @@ function decode_FSCALE_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FSCALE_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5244,8 +5173,7 @@ function decode_FSUB_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FSUB_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5316,8 +5244,7 @@ function decode_FSUBR_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FSUBR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5377,8 +5304,7 @@ function decode_FADDV_V_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FADDV_V_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5438,8 +5364,7 @@ function decode_FMAXNMV_V_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FMAXNMV_V_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5499,8 +5424,7 @@ function decode_FMINNMV_V_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FMINNMV_V_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5560,8 +5484,7 @@ function decode_FMAXV_V_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FMAXV_V_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5621,8 +5544,7 @@ function decode_FMINV_V_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FMINV_V_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5669,7 +5591,7 @@ function execute_FACGE_P_P_ZZ__ (VL, d, esize, g, m, n, op) = {
                   assert(constraint('esize in {16, 32, 64}));
                   res = FPCompareGT(FPAbs(element1), FPAbs(element2), FPCR_read())
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_FACGE_P_P_ZZ__")
             };
             let pbit : bits(1) = if res then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -5711,8 +5633,7 @@ function decode_FACGE_P_P_ZZ__ (size, Zm, Pg, Zn, Pd) = {
       },
       2048 => {
           execute_FACGE_P_P_ZZ__(2048, d, esize, g, m, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5760,7 +5681,7 @@ function execute_FACGT_P_P_ZZ__ (VL, d, esize, g, m, n, op) = {
                   assert(constraint('esize in {16, 32, 64}));
                   res = FPCompareGT(FPAbs(element1), FPAbs(element2), FPCR_read())
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_FACGT_P_P_ZZ__")
             };
             let pbit : bits(1) = if res then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -5802,8 +5723,7 @@ function decode_FACGT_P_P_ZZ__ (size, Zm, Pg, Zn, Pd) = {
       },
       2048 => {
           execute_FACGT_P_P_ZZ__(2048, d, esize, g, m, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -5913,8 +5833,7 @@ function decode_FCMUO_P_P_ZZ__ (size, Zm, Pg, Zn, Pd) = {
       },
       2048 => {
           execute_FCMUO_P_P_ZZ__(2048, d, esize, g, m, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6024,8 +5943,7 @@ function decode_FCMGE_P_P_ZZ__ (size, Zm, cmph, Pg, Zn, cmpl, Pd) = {
       },
       2048 => {
           execute_FCMGE_P_P_ZZ__(2048, d, esize, g, m, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6137,8 +6055,7 @@ function decode_FCMGT_P_P_ZZ__ (size, Zm, cmph, Pg, Zn, cmpl, Pd) = {
       },
       2048 => {
           execute_FCMGT_P_P_ZZ__(2048, d, esize, g, m, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6250,8 +6167,7 @@ function decode_FCMEQ_P_P_ZZ__ (size, Zm, cmph, Pg, Zn, cmpl, Pd) = {
       },
       2048 => {
           execute_FCMEQ_P_P_ZZ__(2048, d, esize, g, m, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6363,8 +6279,7 @@ function decode_FCMNE_P_P_ZZ__ (size, Zm, cmph, Pg, Zn, cmpl, Pd) = {
       },
       2048 => {
           execute_FCMNE_P_P_ZZ__(2048, d, esize, g, m, n, op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6451,8 +6366,7 @@ function decode_FMLA_Z_P_ZZZ__ (size, Zm, N, op, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_FMLA_Z_P_ZZZ__(2048, da, esize, g, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6539,8 +6453,7 @@ function decode_FMLS_Z_P_ZZZ__ (size, Zm, N, op, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_FMLS_Z_P_ZZZ__(2048, da, esize, g, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6630,8 +6543,7 @@ function decode_FNMLA_Z_P_ZZZ__ (size, Zm, N, op, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_FNMLA_Z_P_ZZZ__(2048, da, esize, g, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6721,8 +6633,7 @@ function decode_FNMLS_Z_P_ZZZ__ (size, Zm, N, op, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_FNMLS_Z_P_ZZZ__(2048, da, esize, g, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6812,8 +6723,7 @@ function decode_FMAD_Z_P_ZZZ__ (size, Za, N, op, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAD_Z_P_ZZZ__(2048, a, dn, esize, g, m, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6903,8 +6813,7 @@ function decode_FMSB_Z_P_ZZZ__ (size, Za, N, op, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMSB_Z_P_ZZZ__(2048, a, dn, esize, g, m, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -6994,8 +6903,7 @@ function decode_FNMAD_Z_P_ZZZ__ (size, Za, N, op, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FNMAD_Z_P_ZZZ__(2048, a, dn, esize, g, m, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7085,8 +6993,7 @@ function decode_FNMSB_Z_P_ZZZ__ (size, Za, N, op, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FNMSB_Z_P_ZZZ__(2048, a, dn, esize, g, m, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7149,8 +7056,7 @@ function decode_FADD_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FADD_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7210,8 +7116,7 @@ function decode_FMUL_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FMUL_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7271,8 +7176,7 @@ function decode_FSUB_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FSUB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7335,8 +7239,7 @@ function decode_FTSMUL_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FTSMUL_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7399,8 +7302,7 @@ function decode_FRECPS_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FRECPS_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7463,8 +7365,7 @@ function decode_FRSQRTS_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FRSQRTS_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7527,8 +7428,7 @@ function decode_FTSSEL_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FTSSEL_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7588,8 +7488,7 @@ function decode_FEXPA_Z_Z__ (size, Zn, Zd) = {
       },
       2048 => {
           execute_FEXPA_Z_Z__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7651,8 +7550,7 @@ function decode_FTMAD_Z_ZZI__ (size, imm3, Zm, Zdn) = {
       },
       2048 => {
           execute_FTMAD_Z_ZZI__(2048, dn, esize, imm, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7743,8 +7641,7 @@ function decode_FCADD_Z_P_ZZ__ (size, rot, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FCADD_Z_P_ZZ__(2048, dn, esize, g, m, sub_i, sub_r)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7843,8 +7740,7 @@ function decode_FCMLA_Z_P_ZZZ__ (size, Zm, rot, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_FCMLA_Z_P_ZZZ__(2048, da, esize, g, m, n, neg_i, neg_r, sel_a, sel_b)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -7939,8 +7835,7 @@ function decode_FCMLA_Z_ZZZi_H (size, i2, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_FCMLA_Z_ZZZi_H(2048, da, esize, index, m, n, neg_i, neg_r, sel_a, sel_b)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8035,8 +7930,7 @@ function decode_FCMLA_Z_ZZZi_S (size, i1, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_FCMLA_Z_ZZZi_S(2048, da, esize, index, m, n, neg_i, neg_r, sel_a, sel_b)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8101,8 +7995,7 @@ function decode_FMUL_Z_ZZi_H (i3h, i3l, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FMUL_Z_ZZi_H(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8175,8 +8068,7 @@ function decode_FMLA_Z_ZZZi_H (i3h, i3l, Zm, op, Zn, Zda) = {
       },
       2048 => {
           execute_FMLA_Z_ZZZi_H(2048, da, esize, index, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8250,8 +8142,7 @@ function decode_FMLS_Z_ZZZi_H (i3h, i3l, Zm, op, Zn, Zda) = {
       },
       2048 => {
           execute_FMLS_Z_ZZZi_H(2048, da, esize, index, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8316,8 +8207,7 @@ function decode_FMUL_Z_ZZi_S (size, i2, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FMUL_Z_ZZi_S(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8390,8 +8280,7 @@ function decode_FMLA_Z_ZZZi_S (size, i2, Zm, op, Zn, Zda) = {
       },
       2048 => {
           execute_FMLA_Z_ZZZi_S(2048, da, esize, index, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8465,8 +8354,7 @@ function decode_FMLS_Z_ZZZi_S (size, i2, Zm, op, Zn, Zda) = {
       },
       2048 => {
           execute_FMLS_Z_ZZZi_S(2048, da, esize, index, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8531,8 +8419,7 @@ function decode_FMUL_Z_ZZi_D (size, i1, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FMUL_Z_ZZi_D(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8605,8 +8492,7 @@ function decode_FMLA_Z_ZZZi_D (size, i1, Zm, op, Zn, Zda) = {
       },
       2048 => {
           execute_FMLA_Z_ZZZi_D(2048, da, esize, index, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8680,8 +8566,7 @@ function decode_FMLS_Z_ZZZi_D (size, i1, Zm, op, Zn, Zda) = {
       },
       2048 => {
           execute_FMLS_Z_ZZZi_D(2048, da, esize, index, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8760,8 +8645,7 @@ function decode_FADDP_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FADDP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8838,8 +8722,7 @@ function decode_FMAXNMP_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAXNMP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8916,8 +8799,7 @@ function decode_FMAXP_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMAXP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -8994,8 +8876,7 @@ function decode_FMINNMP_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMINNMP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9072,8 +8953,7 @@ function decode_FMINP_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_FMINP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9138,8 +9018,7 @@ function decode_FMLALB_Z_ZZZ__ (o2, Zm, op, T, Zn, Zda) = {
       },
       2048 => {
           execute_FMLALB_Z_ZZZ__(2048, da, esize, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9206,8 +9085,7 @@ function decode_FMLALT_Z_ZZZ__ (o2, Zm, op, T, Zn, Zda) = {
       },
       2048 => {
           execute_FMLALT_Z_ZZZ__(2048, da, esize, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9274,8 +9152,7 @@ function decode_FMLSLB_Z_ZZZ__ (o2, Zm, op, T, Zn, Zda) = {
       },
       2048 => {
           execute_FMLSLB_Z_ZZZ__(2048, da, esize, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9342,8 +9219,7 @@ function decode_FMLSLT_Z_ZZZ__ (o2, Zm, op, T, Zn, Zda) = {
       },
       2048 => {
           execute_FMLSLT_Z_ZZZ__(2048, da, esize, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9414,8 +9290,7 @@ function decode_FMLALB_Z_ZZZi_S (o2, i3h, Zm, op, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_FMLALB_Z_ZZZi_S(2048, da, esize, index, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9488,8 +9363,7 @@ function decode_FMLALT_Z_ZZZi_S (o2, i3h, Zm, op, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_FMLALT_Z_ZZZi_S(2048, da, esize, index, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9562,8 +9436,7 @@ function decode_FMLSLB_Z_ZZZi_S (o2, i3h, Zm, op, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_FMLSLB_Z_ZZZi_S(2048, da, esize, index, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9636,8 +9509,7 @@ function decode_FMLSLT_Z_ZZZi_S (o2, i3h, Zm, op, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_FMLSLT_Z_ZZZi_S(2048, da, esize, index, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9701,8 +9573,7 @@ function decode_BFMLALB_Z_ZZZ__ (o2, Zm, op, T, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLALB_Z_ZZZ__(2048, da, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9764,8 +9635,7 @@ function decode_BFMLALT_Z_ZZZ__ (o2, Zm, op, T, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLALT_Z_ZZZ__(2048, da, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9831,8 +9701,7 @@ function decode_BFMLSLB_Z_ZZZ__ (o2, Zm, op, T, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLSLB_Z_ZZZ__(2048, da, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9898,8 +9767,7 @@ function decode_BFMLSLT_Z_ZZZ__ (o2, Zm, op, T, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLSLT_Z_ZZZ__(2048, da, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -9965,8 +9833,7 @@ function decode_BFMLALB_Z_ZZZi__ (o2, i3h, Zm, op, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLALB_Z_ZZZi__(2048, da, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10034,8 +9901,7 @@ function decode_BFMLALT_Z_ZZZi__ (o2, i3h, Zm, op, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLALT_Z_ZZZi__(2048, da, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10107,8 +9973,7 @@ function decode_BFMLSLB_Z_ZZZi__ (o2, i3h, Zm, op, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLSLB_Z_ZZZi__(2048, da, index, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10180,8 +10045,7 @@ function decode_BFMLSLT_Z_ZZZi__ (o2, i3h, Zm, op, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLSLT_Z_ZZZi__(2048, da, index, m, n, op1_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10248,8 +10112,7 @@ function decode_BFDOT_Z_ZZZ__ (Zm, Zn, Zda) = {
       },
       2048 => {
           execute_BFDOT_Z_ZZZ__(2048, da, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10315,8 +10178,7 @@ function decode_BFDOT_Z_ZZZi__ (i2, Zm, Zn, Zda) = {
       },
       2048 => {
           execute_BFDOT_Z_ZZZi__(2048, da, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10379,8 +10241,7 @@ function decode_FDOT_Z_ZZZ__ (Zm, Zn, Zda) = {
       },
       2048 => {
           execute_FDOT_Z_ZZZ__(2048, da, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10446,8 +10307,7 @@ function decode_FDOT_Z_ZZZi__ (i2, Zm, Zn, Zda) = {
       },
       2048 => {
           execute_FDOT_Z_ZZZi__(2048, da, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10510,8 +10370,7 @@ function decode_BFCVT_Z_P_Z_S2BF (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_BFCVT_Z_P_Z_S2BF(2048, d, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10572,8 +10431,7 @@ function decode_BFCVTNT_Z_P_Z_S2BF (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_BFCVTNT_Z_P_Z_S2BF(2048, d, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10641,8 +10499,7 @@ function decode_FMMLA_Z_ZZZ_S (Zm, Zn, Zda) = {
       },
       2048 => {
           execute_FMMLA_Z_ZZZ_S(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10710,8 +10567,7 @@ function decode_FMMLA_Z_ZZZ_D (Zm, Zn, Zda) = {
       },
       2048 => {
           execute_FMMLA_Z_ZZZ_D(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10775,8 +10631,7 @@ function decode_BFMMLA_Z_ZZZ__ (Zm, Zn, Zda) = {
       },
       2048 => {
           execute_BFMMLA_Z_ZZZ__(2048, da, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10843,8 +10698,7 @@ function decode_FLOGB_Z_P_Z__ (size, U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FLOGB_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10909,8 +10763,7 @@ function decode_FCVTNT_Z_P_Z_D2S (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTNT_Z_P_Z_D2S(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -10973,8 +10826,7 @@ function decode_FCVTNT_Z_P_Z_S2H (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTNT_Z_P_Z_S2H(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11037,8 +10889,7 @@ function decode_FCVTLT_Z_P_Z_S2D (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTLT_Z_P_Z_S2D(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11101,8 +10952,7 @@ function decode_FCVTLT_Z_P_Z_H2S (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTLT_Z_P_Z_H2S(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11168,8 +11018,7 @@ function decode_FCVTX_Z_P_Z_D2S (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTX_Z_P_Z_D2S(2048, d, d_esize, esize, g, n, s_esize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11232,8 +11081,7 @@ function decode_FCVTXNT_Z_P_Z_D2S (Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FCVTXNT_Z_P_Z_D2S(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11294,8 +11142,7 @@ function decode_FCLAMP_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_FCLAMP_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11373,8 +11220,7 @@ function decode_FADDQV_Z_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FADDQV_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11452,8 +11298,7 @@ function decode_FMAXNMQV_Z_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FMAXNMQV_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11531,8 +11376,7 @@ function decode_FMINNMQV_Z_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FMINNMQV_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11610,8 +11454,7 @@ function decode_FMAXQV_Z_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FMAXQV_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11689,8 +11532,7 @@ function decode_FMINQV_Z_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_FMINQV_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11747,8 +11589,7 @@ function decode_BFADD_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BFADD_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11805,8 +11646,7 @@ function decode_BFMUL_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BFMUL_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11863,8 +11703,7 @@ function decode_BFSUB_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BFSUB_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11929,8 +11768,7 @@ function decode_BFADD_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_BFADD_Z_P_ZZ__(2048, dn, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -11995,8 +11833,7 @@ function decode_BFMUL_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMUL_Z_P_ZZ__(2048, dn, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12061,8 +11898,7 @@ function decode_BFSUB_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_BFSUB_Z_P_ZZ__(2048, dn, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12140,8 +11976,7 @@ function decode_BFMLA_Z_P_ZZZ__ (size, Zm, op, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLA_Z_P_ZZZ__(2048, da, g, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12221,8 +12056,7 @@ function decode_BFMLS_Z_P_ZZZ__ (size, Zm, op, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLS_Z_P_ZZZ__(2048, da, g, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12295,8 +12129,7 @@ function decode_BFMLA_Z_ZZZi_H (i3h, i3l, Zm, op, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLA_Z_ZZZi_H(2048, da, index, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12369,8 +12202,7 @@ function decode_BFMLS_Z_ZZZi_H (i3h, i3l, Zm, op, Zn, Zda) = {
       },
       2048 => {
           execute_BFMLS_Z_ZZZi_H(2048, da, index, m, n, op1_neg, op3_neg)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12434,8 +12266,7 @@ function decode_BFMUL_Z_ZZi_H (i3h, i3l, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BFMUL_Z_ZZi_H(2048, d, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12501,8 +12332,7 @@ function decode_BFMAXNM_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAXNM_Z_P_ZZ__(2048, dn, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12567,8 +12397,7 @@ function decode_BFMINNM_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMINNM_Z_P_ZZ__(2048, dn, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12633,8 +12462,7 @@ function decode_BFMAX_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMAX_Z_P_ZZ__(2048, dn, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12699,8 +12527,7 @@ function decode_BFMIN_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_BFMIN_Z_P_ZZ__(2048, dn, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12760,8 +12587,7 @@ function decode_BFCLAMP_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BFCLAMP_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12822,8 +12648,7 @@ function decode_ADR_Z_AZ_D_u32_scaled (Zm, msz, Zn, Zd) = {
       },
       2048 => {
           execute_ADR_Z_AZ_D_u32_scaled(2048, d, esize, m, mbytes, n, osize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12884,8 +12709,7 @@ function decode_ADR_Z_AZ_D_s32_scaled (Zm, msz, Zn, Zd) = {
       },
       2048 => {
           execute_ADR_Z_AZ_D_s32_scaled(2048, d, esize, m, mbytes, n, osize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -12947,8 +12771,7 @@ function decode_ADR_Z_AZ_SD_same_scaled (sz, Zm, msz, Zn, Zd) = {
       },
       2048 => {
           execute_ADR_Z_AZ_SD_same_scaled(2048, d, esize, m, mbytes, n, osize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13011,8 +12834,7 @@ function decode_ADD_Z_ZI__ (size, sh, imm8, Zdn) = {
       },
       2048 => {
           execute_ADD_Z_ZI__(2048, dn, esize, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13074,8 +12896,7 @@ function decode_SUB_Z_ZI__ (size, sh, imm8, Zdn) = {
       },
       2048 => {
           execute_SUB_Z_ZI__(2048, dn, esize, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13137,8 +12958,7 @@ function decode_SUBR_Z_ZI__ (size, sh, imm8, Zdn) = {
       },
       2048 => {
           execute_SUBR_Z_ZI__(2048, dn, esize, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13193,8 +13013,7 @@ function decode_MUL_Z_ZI__ (size, imm8, Zdn) = {
       },
       2048 => {
           execute_MUL_Z_ZI__(2048, dn, esize, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13249,8 +13068,7 @@ function decode_UMAX_Z_ZI__ (size, U, imm8, Zdn) = {
       },
       2048 => {
           execute_UMAX_Z_ZI__(2048, dn, esize, imm, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13306,8 +13124,7 @@ function decode_SMAX_Z_ZI__ (size, U, imm8, Zdn) = {
       },
       2048 => {
           execute_SMAX_Z_ZI__(2048, dn, esize, imm, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13363,8 +13180,7 @@ function decode_UMIN_Z_ZI__ (size, U, imm8, Zdn) = {
       },
       2048 => {
           execute_UMIN_Z_ZI__(2048, dn, esize, imm, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13420,8 +13236,7 @@ function decode_SMIN_Z_ZI__ (size, U, imm8, Zdn) = {
       },
       2048 => {
           execute_SMIN_Z_ZI__(2048, dn, esize, imm, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13476,8 +13291,7 @@ function decode_ADDPL_R_RI__ (Rn, imm6, Rd) = {
       },
       2048 => {
           execute_ADDPL_R_RI__(2048, d, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13531,8 +13345,7 @@ function decode_ADDVL_R_RI__ (Rn, imm6, Rd) = {
       },
       2048 => {
           execute_ADDVL_R_RI__(2048, d, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13589,8 +13402,7 @@ function decode_ADD_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_ADD_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13640,8 +13452,7 @@ function decode_AND_Z_ZZ__ (Zm, Zn, Zd) = {
       },
       2048 => {
           execute_AND_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13690,8 +13501,7 @@ function decode_BIC_Z_ZZ__ (Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BIC_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13740,8 +13550,7 @@ function decode_EOR_Z_ZZ__ (Zm, Zn, Zd) = {
       },
       2048 => {
           execute_EOR_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13790,8 +13599,7 @@ function decode_ORR_Z_ZZ__ (Zm, Zn, Zd) = {
       },
       2048 => {
           execute_ORR_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13848,8 +13656,7 @@ function decode_SUB_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_SUB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13916,8 +13723,7 @@ function decode_ADD_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_ADD_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -13984,8 +13790,7 @@ function decode_AND_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_AND_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14052,8 +13857,7 @@ function decode_BIC_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_BIC_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14120,8 +13924,7 @@ function decode_EOR_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_EOR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14189,8 +13992,7 @@ function decode_LSL_Z_P_ZZ__ (size, R, L, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_LSL_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14261,8 +14063,7 @@ function decode_LSLR_Z_P_ZZ__ (size, R, L, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_LSLR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14333,8 +14134,7 @@ function decode_MUL_Z_P_ZZ__ (size, H, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_MUL_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14403,8 +14203,7 @@ function decode_ORR_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_ORR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14471,8 +14270,7 @@ function decode_SUB_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SUB_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14539,8 +14337,7 @@ function decode_SUBR_Z_P_ZZ__ (size, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SUBR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14608,8 +14405,7 @@ function decode_LSR_Z_P_ZZ__ (size, R, L, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_LSR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14680,8 +14476,7 @@ function decode_ASR_Z_P_ZZ__ (size, R, L, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_ASR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14752,8 +14547,7 @@ function decode_LSRR_Z_P_ZZ__ (size, R, L, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_LSRR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14824,8 +14618,7 @@ function decode_ASRR_Z_P_ZZ__ (size, R, L, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_ASRR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14897,8 +14690,7 @@ function decode_UABD_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UABD_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -14968,8 +14760,7 @@ function decode_SABD_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SABD_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15051,8 +14842,7 @@ function decode_UDIV_Z_P_ZZ__ (size, R, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UDIV_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15135,8 +14925,7 @@ function decode_SDIV_Z_P_ZZ__ (size, R, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SDIV_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15219,8 +15008,7 @@ function decode_UDIVR_Z_P_ZZ__ (size, R, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UDIVR_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15303,8 +15091,7 @@ function decode_SDIVR_Z_P_ZZ__ (size, R, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SDIVR_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15375,8 +15162,7 @@ function decode_UMAX_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UMAX_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15446,8 +15232,7 @@ function decode_SMAX_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SMAX_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15517,8 +15302,7 @@ function decode_UMIN_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UMIN_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15588,8 +15372,7 @@ function decode_SMIN_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SMIN_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15659,8 +15442,7 @@ function decode_UMULH_Z_P_ZZ__ (size, H, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UMULH_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15731,8 +15513,7 @@ function decode_SMULH_Z_P_ZZ__ (size, H, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SMULH_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15771,7 +15552,7 @@ function execute_WHILELO_P_P_RR__ (VL, d, esize, m, n, op, rsize, is_unsigned) =
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELO_P_P_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -15811,8 +15592,7 @@ function decode_WHILELO_P_P_RR__ (size, Rm, sf, U, lt, Rn, eq, Pd) = {
       },
       2048 => {
           execute_WHILELO_P_P_RR__(2048, d, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15853,7 +15633,7 @@ function execute_WHILELS_P_P_RR__ (VL, d, esize, m, n, op, rsize, is_unsigned) =
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELS_P_P_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -15893,8 +15673,7 @@ function decode_WHILELS_P_P_RR__ (size, Rm, sf, U, lt, Rn, eq, Pd) = {
       },
       2048 => {
           execute_WHILELS_P_P_RR__(2048, d, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -15935,7 +15714,7 @@ function execute_WHILELT_P_P_RR__ (VL, d, esize, m, n, op, rsize, is_unsigned) =
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELT_P_P_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -15975,8 +15754,7 @@ function decode_WHILELT_P_P_RR__ (size, Rm, sf, U, lt, Rn, eq, Pd) = {
       },
       2048 => {
           execute_WHILELT_P_P_RR__(2048, d, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16017,7 +15795,7 @@ function execute_WHILELE_P_P_RR__ (VL, d, esize, m, n, op, rsize, is_unsigned) =
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELE_P_P_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -16057,8 +15835,7 @@ function decode_WHILELE_P_P_RR__ (size, Rm, sf, U, lt, Rn, eq, Pd) = {
       },
       2048 => {
           execute_WHILELE_P_P_RR__(2048, d, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16099,7 +15876,7 @@ function execute_WHILEHI_P_P_RR__ (VL, d, esize, m, n, op, rsize, is_unsigned) =
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEHI_P_P_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -16139,8 +15916,7 @@ function decode_WHILEHI_P_P_RR__ (size, Rm, sf, U, lt, Rn, eq, Pd) = {
       },
       2048 => {
           execute_WHILEHI_P_P_RR__(2048, d, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16181,7 +15957,7 @@ function execute_WHILEHS_P_P_RR__ (VL, d, esize, m, n, op, rsize, is_unsigned) =
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEHS_P_P_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -16221,8 +15997,7 @@ function decode_WHILEHS_P_P_RR__ (size, Rm, sf, U, lt, Rn, eq, Pd) = {
       },
       2048 => {
           execute_WHILEHS_P_P_RR__(2048, d, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16263,7 +16038,7 @@ function execute_WHILEGT_P_P_RR__ (VL, d, esize, m, n, op, rsize, is_unsigned) =
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEGT_P_P_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -16303,8 +16078,7 @@ function decode_WHILEGT_P_P_RR__ (size, Rm, sf, U, lt, Rn, eq, Pd) = {
       },
       2048 => {
           execute_WHILEGT_P_P_RR__(2048, d, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16345,7 +16119,7 @@ function execute_WHILEGE_P_P_RR__ (VL, d, esize, m, n, op, rsize, is_unsigned) =
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEGE_P_P_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -16385,8 +16159,7 @@ function decode_WHILEGE_P_P_RR__ (size, Rm, sf, U, lt, Rn, eq, Pd) = {
       },
       2048 => {
           execute_WHILEGE_P_P_RR__(2048, d, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16442,7 +16215,7 @@ function execute_CMPEQ_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPEQ_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -16483,8 +16256,7 @@ function decode_CMPEQ_P_P_ZI__ (size, imm5, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPEQ_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16538,7 +16310,7 @@ function execute_CMPNE_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPNE_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -16579,8 +16351,7 @@ function decode_CMPNE_P_P_ZI__ (size, imm5, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPNE_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16634,7 +16405,7 @@ function execute_CMPHS_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPHS_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -16675,8 +16446,7 @@ function decode_CMPHS_P_P_ZI__ (size, imm7, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPHS_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16731,7 +16501,7 @@ function execute_CMPHI_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPHI_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -16772,8 +16542,7 @@ function decode_CMPHI_P_P_ZI__ (size, imm7, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPHI_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16828,7 +16597,7 @@ function execute_CMPLO_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPLO_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -16869,8 +16638,7 @@ function decode_CMPLO_P_P_ZI__ (size, imm7, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPLO_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -16925,7 +16693,7 @@ function execute_CMPLS_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPLS_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -16966,8 +16734,7 @@ function decode_CMPLS_P_P_ZI__ (size, imm7, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPLS_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17022,7 +16789,7 @@ function execute_CMPGE_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPGE_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17063,8 +16830,7 @@ function decode_CMPGE_P_P_ZI__ (size, imm5, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPGE_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17119,7 +16885,7 @@ function execute_CMPGT_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPGT_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17160,8 +16926,7 @@ function decode_CMPGT_P_P_ZI__ (size, imm5, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPGT_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17216,7 +16981,7 @@ function execute_CMPLT_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPLT_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17257,8 +17022,7 @@ function decode_CMPLT_P_P_ZI__ (size, imm5, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPLT_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17313,7 +17077,7 @@ function execute_CMPLE_P_P_ZI__ (VL, d, esize, g, imm, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= imm
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPLE_P_P_ZI__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17354,8 +17118,7 @@ function decode_CMPLE_P_P_ZI__ (size, imm5, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPLE_P_P_ZI__(2048, d, esize, g, imm, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17415,7 +17178,7 @@ function execute_CMPEQ_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPEQ_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17459,8 +17222,7 @@ function decode_CMPEQ_P_P_ZW__ (size, Zm, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPEQ_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17519,7 +17281,7 @@ function execute_CMPNE_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPNE_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17563,8 +17325,7 @@ function decode_CMPNE_P_P_ZW__ (size, Zm, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPNE_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17623,7 +17384,7 @@ function execute_CMPHS_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPHS_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17667,8 +17428,7 @@ function decode_CMPHS_P_P_ZW__ (size, Zm, U, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPHS_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17729,7 +17489,7 @@ function execute_CMPHI_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPHI_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17773,8 +17533,7 @@ function decode_CMPHI_P_P_ZW__ (size, Zm, U, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPHI_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17835,7 +17594,7 @@ function execute_CMPLO_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPLO_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17879,8 +17638,7 @@ function decode_CMPLO_P_P_ZW__ (size, Zm, U, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPLO_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -17941,7 +17699,7 @@ function execute_CMPLS_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPLS_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -17985,8 +17743,7 @@ function decode_CMPLS_P_P_ZW__ (size, Zm, U, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPLS_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18047,7 +17804,7 @@ function execute_CMPGE_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPGE_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -18091,8 +17848,7 @@ function decode_CMPGE_P_P_ZW__ (size, Zm, U, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPGE_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18153,7 +17909,7 @@ function execute_CMPGT_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPGT_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -18197,8 +17953,7 @@ function decode_CMPGT_P_P_ZW__ (size, Zm, U, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPGT_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18259,7 +18014,7 @@ function execute_CMPLT_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPLT_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -18303,8 +18058,7 @@ function decode_CMPLT_P_P_ZW__ (size, Zm, U, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPLT_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18365,7 +18119,7 @@ function execute_CMPLE_P_P_ZW__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPLE_P_P_ZW__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -18409,8 +18163,7 @@ function decode_CMPLE_P_P_ZW__ (size, Zm, U, lt, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPLE_P_P_ZW__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18471,7 +18224,7 @@ function execute_CMPEQ_P_P_ZZ__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPEQ_P_P_ZZ__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -18512,8 +18265,7 @@ function decode_CMPEQ_P_P_ZZ__ (size, Zm, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPEQ_P_P_ZZ__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18572,7 +18324,7 @@ function execute_CMPNE_P_P_ZZ__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPNE_P_P_ZZ__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -18613,8 +18365,7 @@ function decode_CMPNE_P_P_ZZ__ (size, Zm, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPNE_P_P_ZZ__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18673,7 +18424,7 @@ function execute_CMPGE_P_P_ZZ__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPGE_P_P_ZZ__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -18714,8 +18465,7 @@ function decode_CMPGE_P_P_ZZ__ (size, Zm, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPGE_P_P_ZZ__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18774,7 +18524,7 @@ function execute_CMPGT_P_P_ZZ__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPGT_P_P_ZZ__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -18815,8 +18565,7 @@ function decode_CMPGT_P_P_ZZ__ (size, Zm, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPGT_P_P_ZZ__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18875,7 +18624,7 @@ function execute_CMPHS_P_P_ZZ__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPHS_P_P_ZZ__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -18916,8 +18665,7 @@ function decode_CMPHS_P_P_ZZ__ (size, Zm, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPHS_P_P_ZZ__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -18976,7 +18724,7 @@ function execute_CMPHI_P_P_ZZ__ (VL, d, esize, g, m, n, op, is_unsigned) = {
               Cmp_LE => {
                   cond = element1 <= element2
               },
-              _ => ()
+              _ => PatternMatchFailure("execute_CMPHI_P_P_ZZ__")
             };
             let pbit : bits(1) = if cond then 0b1 else 0b0;
             result = Elem_set(result, e, psize, ZeroExtend(pbit, psize))
@@ -19017,8 +18765,7 @@ function decode_CMPHI_P_P_ZZ__ (size, Zm, Pg, Zn, ne, Pd) = {
       },
       2048 => {
           execute_CMPHI_P_P_ZZ__(2048, d, esize, g, m, n, op, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19080,8 +18827,7 @@ function decode_DECP_R_P_R__ (size, D, Pm, Rdn) = {
       },
       2048 => {
           execute_DECP_R_P_R__(2048, dn, esize, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19141,8 +18887,7 @@ function decode_INCP_R_P_R__ (size, D, Pm, Rdn) = {
       },
       2048 => {
           execute_INCP_R_P_R__(2048, dn, esize, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19211,8 +18956,7 @@ function decode_UQINCP_R_P_R_UW (size, D, U, sf, Pm, Rdn) = {
       },
       2048 => {
           execute_UQINCP_R_P_R_UW(2048, dn, esize, m, ssize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19283,8 +19027,7 @@ function decode_SQINCP_R_P_R_SX (size, D, U, sf, Pm, Rdn) = {
       },
       2048 => {
           execute_SQINCP_R_P_R_SX(2048, dn, esize, m, ssize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19355,8 +19098,7 @@ function decode_UQINCP_R_P_R_X (size, D, U, sf, Pm, Rdn) = {
       },
       2048 => {
           execute_UQINCP_R_P_R_X(2048, dn, esize, m, ssize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19427,8 +19169,7 @@ function decode_SQINCP_R_P_R_X (size, D, U, sf, Pm, Rdn) = {
       },
       2048 => {
           execute_SQINCP_R_P_R_X(2048, dn, esize, m, ssize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19499,8 +19240,7 @@ function decode_UQDECP_R_P_R_UW (size, D, U, sf, Pm, Rdn) = {
       },
       2048 => {
           execute_UQDECP_R_P_R_UW(2048, dn, esize, m, ssize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19571,8 +19311,7 @@ function decode_SQDECP_R_P_R_SX (size, D, U, sf, Pm, Rdn) = {
       },
       2048 => {
           execute_SQDECP_R_P_R_SX(2048, dn, esize, m, ssize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19643,8 +19382,7 @@ function decode_UQDECP_R_P_R_X (size, D, U, sf, Pm, Rdn) = {
       },
       2048 => {
           execute_UQDECP_R_P_R_X(2048, dn, esize, m, ssize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19715,8 +19453,7 @@ function decode_SQDECP_R_P_R_X (size, D, U, sf, Pm, Rdn) = {
       },
       2048 => {
           execute_SQDECP_R_P_R_X(2048, dn, esize, m, ssize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19785,8 +19522,7 @@ function decode_DECP_Z_P_Z__ (size, D, Pm, Zdn) = {
       },
       2048 => {
           execute_DECP_Z_P_Z__(2048, dn, esize, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19853,8 +19589,7 @@ function decode_INCP_Z_P_Z__ (size, D, Pm, Zdn) = {
       },
       2048 => {
           execute_INCP_Z_P_Z__(2048, dn, esize, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19924,8 +19659,7 @@ function decode_UQINCP_Z_P_Z__ (size, D, U, Pm, Zdn) = {
       },
       2048 => {
           execute_UQINCP_Z_P_Z__(2048, dn, esize, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -19996,8 +19730,7 @@ function decode_SQINCP_Z_P_Z__ (size, D, U, Pm, Zdn) = {
       },
       2048 => {
           execute_SQINCP_Z_P_Z__(2048, dn, esize, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20068,8 +19801,7 @@ function decode_UQDECP_Z_P_Z__ (size, D, U, Pm, Zdn) = {
       },
       2048 => {
           execute_UQDECP_Z_P_Z__(2048, dn, esize, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20140,8 +19872,7 @@ function decode_SQDECP_Z_P_Z__ (size, D, U, Pm, Zdn) = {
       },
       2048 => {
           execute_SQDECP_Z_P_Z__(2048, dn, esize, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20193,8 +19924,7 @@ function decode_DECB_R_RS__ (size, imm4, D, pattern, Rdn) = {
       },
       2048 => {
           execute_DECB_R_RS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20246,8 +19976,7 @@ function decode_DECH_R_RS__ (size, imm4, D, pattern, Rdn) = {
       },
       2048 => {
           execute_DECH_R_RS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20299,8 +20028,7 @@ function decode_DECW_R_RS__ (size, imm4, D, pattern, Rdn) = {
       },
       2048 => {
           execute_DECW_R_RS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20352,8 +20080,7 @@ function decode_DECD_R_RS__ (size, imm4, D, pattern, Rdn) = {
       },
       2048 => {
           execute_DECD_R_RS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20405,8 +20132,7 @@ function decode_INCB_R_RS__ (size, imm4, D, pattern, Rdn) = {
       },
       2048 => {
           execute_INCB_R_RS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20458,8 +20184,7 @@ function decode_INCH_R_RS__ (size, imm4, D, pattern, Rdn) = {
       },
       2048 => {
           execute_INCH_R_RS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20511,8 +20236,7 @@ function decode_INCW_R_RS__ (size, imm4, D, pattern, Rdn) = {
       },
       2048 => {
           execute_INCW_R_RS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -20564,8 +20288,7 @@ function decode_INCD_R_RS__ (size, imm4, D, pattern, Rdn) = {
       },
       2048 => {
           execute_INCD_R_RS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22222,8 +21945,7 @@ function decode_DECH_Z_ZS__ (size, imm4, D, pattern, Zdn) = {
       },
       2048 => {
           execute_DECH_Z_ZS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22280,8 +22002,7 @@ function decode_DECW_Z_ZS__ (size, imm4, D, pattern, Zdn) = {
       },
       2048 => {
           execute_DECW_Z_ZS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22338,8 +22059,7 @@ function decode_DECD_Z_ZS__ (size, imm4, D, pattern, Zdn) = {
       },
       2048 => {
           execute_DECD_Z_ZS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22396,8 +22116,7 @@ function decode_INCH_Z_ZS__ (size, imm4, D, pattern, Zdn) = {
       },
       2048 => {
           execute_INCH_Z_ZS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22454,8 +22173,7 @@ function decode_INCW_Z_ZS__ (size, imm4, D, pattern, Zdn) = {
       },
       2048 => {
           execute_INCW_Z_ZS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22512,8 +22230,7 @@ function decode_INCD_Z_ZS__ (size, imm4, D, pattern, Zdn) = {
       },
       2048 => {
           execute_INCD_Z_ZS__(2048, dn, esize, imm, pat)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22573,8 +22290,7 @@ function decode_UQINCH_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_UQINCH_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22635,8 +22351,7 @@ function decode_UQINCW_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_UQINCW_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22697,8 +22412,7 @@ function decode_UQINCD_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_UQINCD_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22759,8 +22473,7 @@ function decode_SQINCH_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_SQINCH_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22821,8 +22534,7 @@ function decode_SQINCW_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_SQINCW_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22883,8 +22595,7 @@ function decode_SQINCD_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_SQINCD_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -22945,8 +22656,7 @@ function decode_UQDECH_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_UQDECH_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23007,8 +22717,7 @@ function decode_UQDECW_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_UQDECW_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23069,8 +22778,7 @@ function decode_UQDECD_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_UQDECD_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23131,8 +22839,7 @@ function decode_SQDECH_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_SQDECH_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23193,8 +22900,7 @@ function decode_SQDECW_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_SQDECW_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23255,8 +22961,7 @@ function decode_SQDECD_Z_ZS__ (size, imm4, D, U, pattern, Zdn) = {
       },
       2048 => {
           execute_SQDECD_Z_ZS__(2048, dn, esize, imm, pat, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23289,7 +22994,7 @@ function execute_CTERMEQ_RR__ (esize, m, n, op) = {
       Cmp_NE => {
           term = element1 != element2
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_CTERMEQ_RR__")
     };
     if term then {
         PSTATE.N = 0b1;
@@ -23340,7 +23045,7 @@ function execute_CTERMNE_RR__ (esize, m, n, op) = {
       Cmp_NE => {
           term = element1 != element2
       },
-      _ => ()
+      _ => PatternMatchFailure("execute_CTERMNE_RR__")
     };
     if term then {
         PSTATE.N = 0b1;
@@ -23417,8 +23122,7 @@ function decode_FDUP_Z_I__ (size, imm8, Zd) = {
       },
       2048 => {
           execute_FDUP_Z_I__(2048, d, esize, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23480,8 +23184,7 @@ function decode_FCPY_Z_P_I__ (size, Pg, imm8, Zd) = {
       },
       2048 => {
           execute_FCPY_Z_P_I__(2048, d, esize, g, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23538,8 +23241,7 @@ function decode_DUP_Z_I__ (size, sh, imm8, Zd) = {
       },
       2048 => {
           execute_DUP_Z_I__(2048, d, esize, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23610,8 +23312,7 @@ function decode_CPY_Z_P_I__ (size, Pg, M, sh, imm8, Zd) = {
       },
       2048 => {
           execute_CPY_Z_P_I__(2048, d, esize, g, imm, merging)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23684,8 +23385,7 @@ function decode_CPY_Z_O_I__ (size, Pg, M, sh, imm8, Zd) = {
       },
       2048 => {
           execute_CPY_Z_O_I__(2048, d, esize, g, imm, merging)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23742,8 +23442,7 @@ function decode_DUPM_Z_I__ (imm13, Zd) = {
       },
       2048 => {
           execute_DUPM_Z_I__(2048, d, esize, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23810,8 +23509,7 @@ function decode_UXTB_Z_P_Z__ (size, U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UXTB_Z_P_Z__(2048, d, esize, g, n, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23885,8 +23583,7 @@ function decode_UXTH_Z_P_Z__ (size, U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UXTH_Z_P_Z__(2048, d, esize, g, n, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -23957,8 +23654,7 @@ function decode_UXTW_Z_P_Z__ (size, U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_UXTW_Z_P_Z__(2048, d, esize, g, n, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24028,8 +23724,7 @@ function decode_SXTB_Z_P_Z__ (size, U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SXTB_Z_P_Z__(2048, d, esize, g, n, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24103,8 +23798,7 @@ function decode_SXTH_Z_P_Z__ (size, U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SXTH_Z_P_Z__(2048, d, esize, g, n, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24175,8 +23869,7 @@ function decode_SXTW_Z_P_Z__ (size, U, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SXTW_Z_P_Z__(2048, d, esize, g, n, s_esize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24240,8 +23933,7 @@ function decode_ANDV_R_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_ANDV_R_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24304,8 +23996,7 @@ function decode_EORV_R_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_EORV_R_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24368,8 +24059,7 @@ function decode_ORV_R_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_ORV_R_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24434,8 +24124,7 @@ function decode_SADDV_R_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_SADDV_R_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24501,8 +24190,7 @@ function decode_UADDV_R_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_UADDV_R_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24569,8 +24257,7 @@ function decode_UMAXV_R_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_UMAXV_R_P_Z__(2048, d, esize, g, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24637,8 +24324,7 @@ function decode_SMAXV_R_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_SMAXV_R_P_Z__(2048, d, esize, g, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24705,8 +24391,7 @@ function decode_UMINV_R_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_UMINV_R_P_Z__(2048, d, esize, g, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24773,8 +24458,7 @@ function decode_SMINV_R_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_SMINV_R_P_Z__(2048, d, esize, g, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24831,8 +24515,7 @@ function decode_INDEX_Z_II__ (size, imm5b, imm5, Zd) = {
       },
       2048 => {
           execute_INDEX_Z_II__(2048, d, esize, imm1, imm2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24890,8 +24573,7 @@ function decode_INDEX_Z_IR__ (size, Rm, imm5, Zd) = {
       },
       2048 => {
           execute_INDEX_Z_IR__(2048, d, esize, imm, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -24949,8 +24631,7 @@ function decode_INDEX_Z_RI__ (size, imm5, Rn, Zd) = {
       },
       2048 => {
           execute_INDEX_Z_RI__(2048, d, esize, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25010,8 +24691,7 @@ function decode_INDEX_Z_RR__ (size, Rm, Rn, Zd) = {
       },
       2048 => {
           execute_INDEX_Z_RR__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25072,8 +24752,7 @@ function decode_AND_Z_ZI__ (imm13, Zdn) = {
       },
       2048 => {
           execute_AND_Z_ZI__(2048, dn, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25132,8 +24811,7 @@ function decode_EOR_Z_ZI__ (imm13, Zdn) = {
       },
       2048 => {
           execute_EOR_Z_ZI__(2048, dn, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25192,8 +24870,7 @@ function decode_ORR_Z_ZI__ (imm13, Zdn) = {
       },
       2048 => {
           execute_ORR_Z_ZI__(2048, dn, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25269,8 +24946,7 @@ function decode_MAD_Z_P_ZZZ__ (size, Zm, op, Pg, Za, Zdn) = {
       },
       2048 => {
           execute_MAD_Z_P_ZZZ__(2048, a, dn, esize, g, m, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25350,8 +25026,7 @@ function decode_MSB_Z_P_ZZZ__ (size, Zm, op, Pg, Za, Zdn) = {
       },
       2048 => {
           execute_MSB_Z_P_ZZZ__(2048, a, dn, esize, g, m, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25431,8 +25106,7 @@ function decode_MLA_Z_P_ZZZ__ (size, Zm, op, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_MLA_Z_P_ZZZ__(2048, da, esize, g, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25512,8 +25186,7 @@ function decode_MLS_Z_P_ZZZ__ (size, Zm, op, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_MLS_Z_P_ZZZ__(2048, da, esize, g, m, n, sub_op)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25564,8 +25237,7 @@ function decode_MOVPRFX_Z_Z__ (Zn, Zd) = {
       },
       2048 => {
           execute_MOVPRFX_Z_Z__(2048, d, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25632,8 +25304,7 @@ function decode_MOVPRFX_Z_P_Z__ (size, M, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_MOVPRFX_Z_P_Z__(2048, d, esize, g, merging, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25694,8 +25365,7 @@ function decode_CNTP_R_P_P__ (size, Pg, Pn, Rd) = {
       },
       2048 => {
           execute_CNTP_R_P_P__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25746,8 +25416,7 @@ function decode_REV_P_P__ (size, Pn, Pd) = {
       },
       2048 => {
           execute_REV_P_P__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25805,8 +25474,7 @@ function decode_TRN1_P_PP__ (size, Pm, H, Pn, Pd) = {
       },
       2048 => {
           execute_TRN1_P_PP__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25866,8 +25534,7 @@ function decode_TRN2_P_PP__ (size, Pm, H, Pn, Pd) = {
       },
       2048 => {
           execute_TRN2_P_PP__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25929,8 +25596,7 @@ function decode_UZP1_P_PP__ (size, Pm, H, Pn, Pd) = {
       },
       2048 => {
           execute_UZP1_P_PP__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -25992,8 +25658,7 @@ function decode_UZP2_P_PP__ (size, Pm, H, Pn, Pd) = {
       },
       2048 => {
           execute_UZP2_P_PP__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26054,8 +25719,7 @@ function decode_ZIP1_P_PP__ (size, Pm, H, Pn, Pd) = {
       },
       2048 => {
           execute_ZIP1_P_PP__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26116,8 +25780,7 @@ function decode_ZIP2_P_PP__ (size, Pm, H, Pn, Pd) = {
       },
       2048 => {
           execute_ZIP2_P_PP__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26169,8 +25832,7 @@ function decode_REV_Z_Z__ (size, Zn, Zd) = {
       },
       2048 => {
           execute_REV_Z_Z__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26240,8 +25902,7 @@ function decode_TBL_Z_ZZ_1 (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_TBL_Z_ZZ_1(2048, d, double_table, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26312,8 +25973,7 @@ function decode_TBL_Z_ZZ_2 (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_TBL_Z_ZZ_2(2048, d, double_table, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26378,8 +26038,7 @@ function decode_TRN1_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_TRN1_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26445,8 +26104,7 @@ function decode_TRN2_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_TRN2_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26514,8 +26172,7 @@ function decode_UZP1_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_UZP1_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26583,8 +26240,7 @@ function decode_UZP2_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_UZP2_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26651,8 +26307,7 @@ function decode_ZIP1_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_ZIP1_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26719,8 +26374,7 @@ function decode_ZIP2_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_ZIP2_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26786,8 +26440,7 @@ function decode_TRN1_Z_ZZ_Q (Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_TRN1_Z_ZZ_Q(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26852,8 +26505,7 @@ function decode_TRN2_Z_ZZ_Q (Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_TRN2_Z_ZZ_Q(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26919,8 +26571,7 @@ function decode_ZIP1_Z_ZZ_Q (Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_ZIP1_Z_ZZ_Q(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -26986,8 +26637,7 @@ function decode_ZIP2_Z_ZZ_Q (Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_ZIP2_Z_ZZ_Q(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27054,8 +26704,7 @@ function decode_UZP1_Z_ZZ_Q (Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_UZP1_Z_ZZ_Q(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27122,8 +26771,7 @@ function decode_UZP2_Z_ZZ_Q (Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_UZP2_Z_ZZ_Q(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27196,8 +26844,7 @@ function decode_CLASTA_R_P_Z__ (size, B, Pg, Zm, Rdn) = {
       },
       2048 => {
           execute_CLASTA_R_P_Z__(2048, csize, dn, esize, g, isBefore, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27271,8 +26918,7 @@ function decode_CLASTB_R_P_Z__ (size, B, Pg, Zm, Rdn) = {
       },
       2048 => {
           execute_CLASTB_R_P_Z__(2048, csize, dn, esize, g, isBefore, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27343,8 +26989,7 @@ function decode_CLASTA_V_P_Z__ (size, B, Pg, Zm, Vdn) = {
       },
       2048 => {
           execute_CLASTA_V_P_Z__(2048, dn, esize, g, isBefore, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27415,8 +27060,7 @@ function decode_CLASTB_V_P_Z__ (size, B, Pg, Zm, Vdn) = {
       },
       2048 => {
           execute_CLASTB_V_P_Z__(2048, dn, esize, g, isBefore, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27489,8 +27133,7 @@ function decode_CLASTA_Z_P_ZZ__ (size, B, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_CLASTA_Z_P_ZZ__(2048, dn, esize, g, isBefore, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27563,8 +27206,7 @@ function decode_CLASTB_Z_P_ZZ__ (size, B, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_CLASTB_Z_P_ZZ__(2048, dn, esize, g, isBefore, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27640,8 +27282,7 @@ function decode_COMPACT_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_COMPACT_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27724,8 +27365,7 @@ function decode_SPLICE_Z_P_ZZ_Des (size, Pv, Zm, Zdn) = {
       },
       2048 => {
           execute_SPLICE_Z_P_ZZ_Des(2048, dst, esize, s1, s2, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27808,8 +27448,7 @@ function decode_SPLICE_Z_P_ZZ_Con (size, Pv, Zn, Zd) = {
       },
       2048 => {
           execute_SPLICE_Z_P_ZZ_Con(2048, dst, esize, s1, s2, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27871,8 +27510,7 @@ function decode_EXT_Z_ZI_Des (imm8h, imm8l, Zm, Zdn) = {
       },
       2048 => {
           execute_EXT_Z_ZI_Des(2048, dst, esize, position, s1, s2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -27934,8 +27572,7 @@ function decode_EXT_Z_ZI_Con (imm8h, imm8l, Zn, Zd) = {
       },
       2048 => {
           execute_EXT_Z_ZI_Con(2048, dst, esize, position, s1, s2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28002,8 +27639,7 @@ function decode_CPY_Z_P_R__ (size, Pg, Rn, Zd) = {
       },
       2048 => {
           execute_CPY_Z_P_R__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28066,8 +27702,7 @@ function decode_CPY_Z_P_V__ (size, Pg, Vn, Zd) = {
       },
       2048 => {
           execute_CPY_Z_P_V__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28154,8 +27789,7 @@ function decode_DUP_Z_Zi__ (imm2, tsz, Zn, Zd) = {
       },
       2048 => {
           execute_DUP_Z_Zi__(2048, d, esize, index, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28215,8 +27849,7 @@ function decode_DUP_Z_R__ (size, Rn, Zd) = {
       },
       2048 => {
           execute_DUP_Z_R__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28286,8 +27919,7 @@ function decode_LASTA_R_P_Z__ (size, B, Pg, Zn, Rd) = {
       },
       2048 => {
           execute_LASTA_R_P_Z__(2048, d, esize, g, isBefore, n, rsize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28359,8 +27991,7 @@ function decode_LASTB_R_P_Z__ (size, B, Pg, Zn, Rd) = {
       },
       2048 => {
           execute_LASTB_R_P_Z__(2048, d, esize, g, isBefore, n, rsize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28429,8 +28060,7 @@ function decode_LASTA_V_P_Z__ (size, B, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_LASTA_V_P_Z__(2048, d, esize, g, isBefore, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28499,8 +28129,7 @@ function decode_LASTB_V_P_Z__ (size, B, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_LASTB_V_P_Z__(2048, d, esize, g, isBefore, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28561,8 +28190,7 @@ function decode_PUNPKLO_P_P__ (H, Pn, Pd) = {
       },
       2048 => {
           execute_PUNPKLO_P_P__(2048, d, esize, hi, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28621,8 +28249,7 @@ function decode_PUNPKHI_P_P__ (H, Pn, Pd) = {
       },
       2048 => {
           execute_PUNPKHI_P_P__(2048, d, esize, hi, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28689,8 +28316,7 @@ function decode_REVW_Z_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_REVW_Z_Z__(2048, d, esize, g, n, swsize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28761,8 +28387,7 @@ function decode_REVH_Z_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_REVH_Z_Z__(2048, d, esize, g, n, swsize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28830,8 +28455,7 @@ function decode_REVB_Z_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_REVB_Z_Z__(2048, d, esize, g, n, swsize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28896,8 +28520,7 @@ function decode_UUNPKLO_Z_Z__ (size, U, H, Zn, Zd) = {
       },
       2048 => {
           execute_UUNPKLO_Z_Z__(2048, d, esize, hi, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -28963,8 +28586,7 @@ function decode_UUNPKHI_Z_Z__ (size, U, H, Zn, Zd) = {
       },
       2048 => {
           execute_UUNPKHI_Z_Z__(2048, d, esize, hi, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29030,8 +28652,7 @@ function decode_SUNPKLO_Z_Z__ (size, U, H, Zn, Zd) = {
       },
       2048 => {
           execute_SUNPKLO_Z_Z__(2048, d, esize, hi, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29097,8 +28718,7 @@ function decode_SUNPKHI_Z_Z__ (size, U, H, Zn, Zd) = {
       },
       2048 => {
           execute_SUNPKHI_Z_Z__(2048, d, esize, hi, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29143,8 +28763,7 @@ function decode_SETFFR_F__ () = {
       },
       2048 => {
           execute_SETFFR_F__(2048)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29201,8 +28820,7 @@ function decode_PTRUE_P_S__ (size, S, pattern, Pd) = {
       },
       2048 => {
           execute_PTRUE_P_S__(2048, d, esize, pat, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29263,8 +28881,7 @@ function decode_PTRUES_P_S__ (size, S, pattern, Pd) = {
       },
       2048 => {
           execute_PTRUES_P_S__(2048, d, esize, pat, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29311,8 +28928,7 @@ function decode_PFALSE_P__ (S, Pd) = {
       },
       2048 => {
           execute_PFALSE_P__(2048, d)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29358,8 +28974,7 @@ function decode_RDFFR_P_F__ (S, Pd) = {
       },
       2048 => {
           execute_RDFFR_P_F__(2048, d)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29410,8 +29025,7 @@ function decode_WRFFR_F_P__ Pn = {
       },
       2048 => {
           execute_WRFFR_F_P__(2048, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29463,8 +29077,7 @@ function decode_RDFFR_P_P_F__ (S, Pg, Pd) = {
       },
       2048 => {
           execute_RDFFR_P_P_F__(2048, d, g, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29518,8 +29131,7 @@ function decode_RDFFRS_P_P_F__ (S, Pg, Pd) = {
       },
       2048 => {
           execute_RDFFRS_P_P_F__(2048, d, g, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29569,8 +29181,7 @@ function decode_PTEST__P_P__ (S, Pg, Pn) = {
       },
       2048 => {
           execute_PTEST__P_P__(2048, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29644,8 +29255,7 @@ function decode_BRKA_P_P_P__ (B, S, Pg, Pn, M, Pd) = {
       },
       2048 => {
           execute_BRKA_P_P_P__(2048, d, esize, g, merging, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29722,8 +29332,7 @@ function decode_BRKAS_P_P_P_Z (B, S, Pg, Pn, M, Pd) = {
       },
       2048 => {
           execute_BRKAS_P_P_P_Z(2048, d, esize, g, merging, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29800,8 +29409,7 @@ function decode_BRKB_P_P_P__ (B, S, Pg, Pn, M, Pd) = {
       },
       2048 => {
           execute_BRKB_P_P_P__(2048, d, esize, g, merging, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29878,8 +29486,7 @@ function decode_BRKBS_P_P_P_Z (B, S, Pg, Pn, M, Pd) = {
       },
       2048 => {
           execute_BRKBS_P_P_P_Z(2048, d, esize, g, merging, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -29951,8 +29558,7 @@ function decode_AND_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_AND_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30023,8 +29629,7 @@ function decode_ANDS_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_ANDS_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30095,8 +29700,7 @@ function decode_BIC_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_BIC_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30167,8 +29771,7 @@ function decode_BICS_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_BICS_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30239,8 +29842,7 @@ function decode_EOR_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_EOR_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30311,8 +29913,7 @@ function decode_EORS_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_EORS_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30383,8 +29984,7 @@ function decode_NAND_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_NAND_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30455,8 +30055,7 @@ function decode_NANDS_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_NANDS_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30527,8 +30126,7 @@ function decode_NOR_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_NOR_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30599,8 +30197,7 @@ function decode_NORS_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_NORS_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30671,8 +30268,7 @@ function decode_ORN_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_ORN_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30743,8 +30339,7 @@ function decode_ORNS_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_ORNS_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30815,8 +30410,7 @@ function decode_ORR_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_ORR_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30887,8 +30481,7 @@ function decode_ORRS_P_P_PP_Z (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_ORRS_P_P_PP_Z(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -30955,8 +30548,7 @@ function decode_SEL_P_P_PP__ (S, Pm, Pg, Pn, Pd) = {
       },
       2048 => {
           execute_SEL_P_P_PP__(2048, d, esize, g, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31022,8 +30614,7 @@ function decode_PFIRST_P_P_P__ (S, Pg, Pdn) = {
       },
       2048 => {
           execute_PFIRST_P_P_P__(2048, dn, esize, g)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31085,8 +30676,7 @@ function decode_PNEXT_P_P_P__ (size, Pv, Pdn) = {
       },
       2048 => {
           execute_PNEXT_P_P_P__(2048, dn, esize, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31133,8 +30723,7 @@ function decode_RDVL_R_I__ (imm6, Rd) = {
       },
       2048 => {
           execute_RDVL_R_I__(2048, d, imm)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31201,8 +30790,7 @@ function decode_SEL_Z_P_ZZ__ (size, Zm, Pv, Zn, Zd) = {
       },
       2048 => {
           execute_SEL_Z_P_ZZ__(2048, d, esize, m, n, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -31280,8 +30868,7 @@ function decode_LSL_Z_ZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_LSL_Z_ZI__(2048, d, 8, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -31300,8 +30887,7 @@ function decode_LSL_Z_ZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_LSL_Z_ZI__(2048, d, 16, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -31320,8 +30906,7 @@ function decode_LSL_Z_ZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_LSL_Z_ZI__(2048, d, 32, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -31340,8 +30925,7 @@ function decode_LSL_Z_ZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_LSL_Z_ZI__(2048, d, 64, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -31424,8 +31008,7 @@ function decode_LSR_Z_ZI__ (tszh, tszl, imm3, U, Zn, Zd) = {
             },
             2048 => {
                 execute_LSR_Z_ZI__(2048, d, 8, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -31444,8 +31027,7 @@ function decode_LSR_Z_ZI__ (tszh, tszl, imm3, U, Zn, Zd) = {
             },
             2048 => {
                 execute_LSR_Z_ZI__(2048, d, 16, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -31464,8 +31046,7 @@ function decode_LSR_Z_ZI__ (tszh, tszl, imm3, U, Zn, Zd) = {
             },
             2048 => {
                 execute_LSR_Z_ZI__(2048, d, 32, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -31484,8 +31065,7 @@ function decode_LSR_Z_ZI__ (tszh, tszl, imm3, U, Zn, Zd) = {
             },
             2048 => {
                 execute_LSR_Z_ZI__(2048, d, 64, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -31569,8 +31149,7 @@ function decode_ASR_Z_ZI__ (tszh, tszl, imm3, U, Zn, Zd) = {
             },
             2048 => {
                 execute_ASR_Z_ZI__(2048, d, 8, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -31589,8 +31168,7 @@ function decode_ASR_Z_ZI__ (tszh, tszl, imm3, U, Zn, Zd) = {
             },
             2048 => {
                 execute_ASR_Z_ZI__(2048, d, 16, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -31609,8 +31187,7 @@ function decode_ASR_Z_ZI__ (tszh, tszl, imm3, U, Zn, Zd) = {
             },
             2048 => {
                 execute_ASR_Z_ZI__(2048, d, 32, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -31629,8 +31206,7 @@ function decode_ASR_Z_ZI__ (tszh, tszl, imm3, U, Zn, Zd) = {
             },
             2048 => {
                 execute_ASR_Z_ZI__(2048, d, 64, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -31724,8 +31300,7 @@ function decode_ASRD_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_ASRD_Z_P_ZI__(2048, dn, 8, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -31744,8 +31319,7 @@ function decode_ASRD_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_ASRD_Z_P_ZI__(2048, dn, 16, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -31764,8 +31338,7 @@ function decode_ASRD_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_ASRD_Z_P_ZI__(2048, dn, 32, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -31784,8 +31357,7 @@ function decode_ASRD_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_ASRD_Z_P_ZI__(2048, dn, 64, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -31876,8 +31448,7 @@ function decode_LSL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_LSL_Z_P_ZI__(2048, dn, 8, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -31896,8 +31467,7 @@ function decode_LSL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_LSL_Z_P_ZI__(2048, dn, 16, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -31916,8 +31486,7 @@ function decode_LSL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_LSL_Z_P_ZI__(2048, dn, 32, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -31936,8 +31505,7 @@ function decode_LSL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_LSL_Z_P_ZI__(2048, dn, 64, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -32028,8 +31596,7 @@ function decode_LSR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_LSR_Z_P_ZI__(2048, dn, 8, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -32048,8 +31615,7 @@ function decode_LSR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_LSR_Z_P_ZI__(2048, dn, 16, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -32068,8 +31634,7 @@ function decode_LSR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_LSR_Z_P_ZI__(2048, dn, 32, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -32088,8 +31653,7 @@ function decode_LSR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_LSR_Z_P_ZI__(2048, dn, 64, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -32180,8 +31744,7 @@ function decode_ASR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_ASR_Z_P_ZI__(2048, dn, 8, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -32200,8 +31763,7 @@ function decode_ASR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_ASR_Z_P_ZI__(2048, dn, 16, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -32220,8 +31782,7 @@ function decode_ASR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_ASR_Z_P_ZI__(2048, dn, 32, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -32240,8 +31801,7 @@ function decode_ASR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_ASR_Z_P_ZI__(2048, dn, 64, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -32312,8 +31872,7 @@ function decode_LSL_Z_ZW__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_LSL_Z_ZW__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32376,8 +31935,7 @@ function decode_LSR_Z_ZW__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_LSR_Z_ZW__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32441,8 +31999,7 @@ function decode_ASR_Z_ZW__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_ASR_Z_ZW__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32514,8 +32071,7 @@ function decode_LSL_Z_P_ZW__ (size, R, L, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_LSL_Z_P_ZW__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32589,8 +32145,7 @@ function decode_LSR_Z_P_ZW__ (size, R, L, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_LSR_Z_P_ZW__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32664,8 +32219,7 @@ function decode_ASR_Z_P_ZW__ (size, R, L, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_ASR_Z_P_ZW__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32733,8 +32287,7 @@ function decode_ABS_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_ABS_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32798,8 +32351,7 @@ function decode_CLS_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_CLS_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32863,8 +32415,7 @@ function decode_CLZ_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_CLZ_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32928,8 +32479,7 @@ function decode_CNOT_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_CNOT_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -32993,8 +32543,7 @@ function decode_CNT_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_CNT_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33062,8 +32611,7 @@ function decode_FABS_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FABS_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33131,8 +32679,7 @@ function decode_FNEG_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_FNEG_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33197,8 +32744,7 @@ function decode_NEG_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_NEG_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33262,8 +32808,7 @@ function decode_NOT_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_NOT_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33327,8 +32872,7 @@ function decode_RBIT_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_RBIT_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33388,8 +32932,7 @@ function decode_UQADD_Z_ZZ__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_UQADD_Z_ZZ__(2048, d, esize, m, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33450,8 +32993,7 @@ function decode_SQADD_Z_ZZ__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_SQADD_Z_ZZ__(2048, d, esize, m, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33512,8 +33054,7 @@ function decode_UQSUB_Z_ZZ__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_UQSUB_Z_ZZ__(2048, d, esize, m, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33574,8 +33115,7 @@ function decode_SQSUB_Z_ZZ__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_SQSUB_Z_ZZ__(2048, d, esize, m, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33640,8 +33180,7 @@ function decode_UQADD_Z_ZI__ (size, U, sh, imm8, Zdn) = {
       },
       2048 => {
           execute_UQADD_Z_ZI__(2048, dn, esize, imm, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33706,8 +33245,7 @@ function decode_SQADD_Z_ZI__ (size, U, sh, imm8, Zdn) = {
       },
       2048 => {
           execute_SQADD_Z_ZI__(2048, dn, esize, imm, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33772,8 +33310,7 @@ function decode_UQSUB_Z_ZI__ (size, U, sh, imm8, Zdn) = {
       },
       2048 => {
           execute_UQSUB_Z_ZI__(2048, dn, esize, imm, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33838,8 +33375,7 @@ function decode_SQSUB_Z_ZI__ (size, U, sh, imm8, Zdn) = {
       },
       2048 => {
           execute_SQSUB_Z_ZI__(2048, dn, esize, imm, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33910,8 +33446,7 @@ function decode_BRKPA_P_P_PP__ (S, Pm, Pg, Pn, B, Pd) = {
       },
       2048 => {
           execute_BRKPA_P_P_PP__(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -33983,8 +33518,7 @@ function decode_BRKPAS_P_P_PP__ (S, Pm, Pg, Pn, B, Pd) = {
       },
       2048 => {
           execute_BRKPAS_P_P_PP__(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34056,8 +33590,7 @@ function decode_BRKPB_P_P_PP__ (S, Pm, Pg, Pn, B, Pd) = {
       },
       2048 => {
           execute_BRKPB_P_P_PP__(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34129,8 +33662,7 @@ function decode_BRKPBS_P_P_PP__ (S, Pm, Pg, Pn, B, Pd) = {
       },
       2048 => {
           execute_BRKPBS_P_P_PP__(2048, d, esize, g, m, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34194,8 +33726,7 @@ function decode_BRKN_P_P_PP__ (S, Pg, Pn, Pdm) = {
       },
       2048 => {
           execute_BRKN_P_P_PP__(2048, dm, g, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34257,8 +33788,7 @@ function decode_BRKNS_P_P_PP__ (S, Pg, Pn, Pdm) = {
       },
       2048 => {
           execute_BRKNS_P_P_PP__(2048, dm, g, n, setflags)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34309,8 +33839,7 @@ function decode_INSR_Z_V__ (size, Vm, Zdn) = {
       },
       2048 => {
           execute_INSR_Z_V__(2048, dn, esize, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34360,8 +33889,7 @@ function decode_INSR_Z_R__ (size, Rm, Zdn) = {
       },
       2048 => {
           execute_INSR_Z_R__(2048, dn, esize, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34430,8 +33958,7 @@ function decode_SDOT_Z_ZZZ__ (size, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_SDOT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34500,8 +34027,7 @@ function decode_SDOT_Z_ZZZi_S (size, i2, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_SDOT_Z_ZZZi_S(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34571,8 +34097,7 @@ function decode_SDOT_Z_ZZZi_D (size, i1, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_SDOT_Z_ZZZi_D(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34644,8 +34169,7 @@ function decode_UDOT_Z_ZZZ__ (size, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_UDOT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34714,8 +34238,7 @@ function decode_UDOT_Z_ZZZi_S (size, i2, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_UDOT_Z_ZZZi_S(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34785,8 +34308,7 @@ function decode_UDOT_Z_ZZZi_D (size, i1, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_UDOT_Z_ZZZi_D(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34852,8 +34374,7 @@ function decode_USDOT_Z_ZZZ_S (size, Zm, Zn, Zda) = {
       },
       2048 => {
           execute_USDOT_Z_ZZZ_S(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34921,8 +34442,7 @@ function decode_USDOT_Z_ZZZi_S (size, i2, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_USDOT_Z_ZZZi_S(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -34992,8 +34512,7 @@ function decode_SUDOT_Z_ZZZi_S (size, i2, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_SUDOT_Z_ZZZi_S(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35059,8 +34578,7 @@ function decode_SDOT_Z32_ZZZ__ (Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_SDOT_Z32_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35128,8 +34646,7 @@ function decode_SDOT_Z32_ZZZi__ (i2, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_SDOT_Z32_ZZZi__(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35194,8 +34711,7 @@ function decode_UDOT_Z32_ZZZ__ (Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_UDOT_Z32_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35263,8 +34779,7 @@ function decode_UDOT_Z32_ZZZi__ (i2, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_UDOT_Z32_ZZZi__(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35330,8 +34845,7 @@ function decode_SQABS_Z_P_Z__ (size, Q, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SQABS_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35397,8 +34911,7 @@ function decode_SQNEG_Z_P_Z__ (size, Q, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_SQNEG_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35458,8 +34971,7 @@ function decode_SQDMULH_Z_ZZ__ (size, Zm, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULH_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35519,8 +35031,7 @@ function decode_SQRDMULH_Z_ZZ__ (size, Zm, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQRDMULH_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35582,8 +35093,7 @@ function decode_SQRDMLAH_Z_ZZZ__ (size, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDMLAH_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35645,8 +35155,7 @@ function decode_SQRDMLSH_Z_ZZZ__ (size, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDMLSH_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35722,8 +35231,7 @@ function decode_ADDP_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_ADDP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35799,8 +35307,7 @@ function decode_UMAXP_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UMAXP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35876,8 +35383,7 @@ function decode_SMAXP_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SMAXP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -35953,8 +35459,7 @@ function decode_UMINP_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UMINP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36030,8 +35535,7 @@ function decode_SMINP_Z_P_ZZ__ (size, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SMINP_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36103,8 +35607,7 @@ function decode_SADALP_Z_P_Z__ (size, U, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_SADALP_Z_P_Z__(2048, da, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36176,8 +35679,7 @@ function decode_UADALP_Z_P_Z__ (size, U, Pg, Zn, Zda) = {
       },
       2048 => {
           execute_UADALP_Z_P_Z__(2048, da, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36253,8 +35755,7 @@ function decode_SHRNB_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SHRNB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36332,8 +35833,7 @@ function decode_SHRNT_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SHRNT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36412,8 +35912,7 @@ function decode_RSHRNB_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_RSHRNB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36491,8 +35990,7 @@ function decode_RSHRNT_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_RSHRNT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36571,8 +36069,7 @@ function decode_SQSHRNB_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQSHRNB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36650,8 +36147,7 @@ function decode_SQSHRNT_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQSHRNT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36730,8 +36226,7 @@ function decode_UQSHRNB_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_UQSHRNB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36809,8 +36304,7 @@ function decode_UQSHRNT_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_UQSHRNT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36889,8 +36383,7 @@ function decode_SQRSHRNB_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQRSHRNB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -36968,8 +36461,7 @@ function decode_SQRSHRNT_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQRSHRNT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37048,8 +36540,7 @@ function decode_UQRSHRNB_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_UQRSHRNB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37127,8 +36618,7 @@ function decode_UQRSHRNT_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_UQRSHRNT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37207,8 +36697,7 @@ function decode_SQSHRUNB_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQSHRUNB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37286,8 +36775,7 @@ function decode_SQSHRUNT_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQSHRUNT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37366,8 +36854,7 @@ function decode_SQRSHRUNB_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQRSHRUNB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37445,8 +36932,7 @@ function decode_SQRSHRUNT_Z_ZI__ (tszh, tszl, imm3, U, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQRSHRUNT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -37534,8 +37020,7 @@ function decode_SRSHR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SRSHR_Z_P_ZI__(2048, dn, 8, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -37554,8 +37039,7 @@ function decode_SRSHR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SRSHR_Z_P_ZI__(2048, dn, 16, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -37574,8 +37058,7 @@ function decode_SRSHR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SRSHR_Z_P_ZI__(2048, dn, 32, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -37594,8 +37077,7 @@ function decode_SRSHR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SRSHR_Z_P_ZI__(2048, dn, 64, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -37687,8 +37169,7 @@ function decode_URSHR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_URSHR_Z_P_ZI__(2048, dn, 8, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -37707,8 +37188,7 @@ function decode_URSHR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_URSHR_Z_P_ZI__(2048, dn, 16, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -37727,8 +37207,7 @@ function decode_URSHR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_URSHR_Z_P_ZI__(2048, dn, 32, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -37747,8 +37226,7 @@ function decode_URSHR_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_URSHR_Z_P_ZI__(2048, dn, 64, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -37840,8 +37318,7 @@ function decode_SQSHL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SQSHL_Z_P_ZI__(2048, dn, 8, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -37860,8 +37337,7 @@ function decode_SQSHL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SQSHL_Z_P_ZI__(2048, dn, 16, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -37880,8 +37356,7 @@ function decode_SQSHL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SQSHL_Z_P_ZI__(2048, dn, 32, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -37900,8 +37375,7 @@ function decode_SQSHL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SQSHL_Z_P_ZI__(2048, dn, 64, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -37993,8 +37467,7 @@ function decode_UQSHL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_UQSHL_Z_P_ZI__(2048, dn, 8, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -38013,8 +37486,7 @@ function decode_UQSHL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_UQSHL_Z_P_ZI__(2048, dn, 16, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -38033,8 +37505,7 @@ function decode_UQSHL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_UQSHL_Z_P_ZI__(2048, dn, 32, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -38053,8 +37524,7 @@ function decode_UQSHL_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_UQSHL_Z_P_ZI__(2048, dn, 64, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -38146,8 +37616,7 @@ function decode_SQSHLU_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SQSHLU_Z_P_ZI__(2048, dn, 8, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -38166,8 +37635,7 @@ function decode_SQSHLU_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SQSHLU_Z_P_ZI__(2048, dn, 16, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -38186,8 +37654,7 @@ function decode_SQSHLU_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SQSHLU_Z_P_ZI__(2048, dn, 32, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -38206,8 +37673,7 @@ function decode_SQSHLU_Z_P_ZI__ (tszh, L, U, Pg, tszl, imm3, Zdn) = {
             },
             2048 => {
                 execute_SQSHLU_Z_P_ZI__(2048, dn, 64, g, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -38289,8 +37755,7 @@ function decode_SSHLLB_Z_ZI__ (tszh, tszl, imm3, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SSHLLB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38367,8 +37832,7 @@ function decode_SSHLLT_Z_ZI__ (tszh, tszl, imm3, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SSHLLT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38445,8 +37909,7 @@ function decode_USHLLB_Z_ZI__ (tszh, tszl, imm3, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_USHLLB_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38523,8 +37986,7 @@ function decode_USHLLT_Z_ZI__ (tszh, tszl, imm3, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_USHLLT_Z_ZI__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38602,8 +38064,7 @@ function decode_SQXTNB_Z_ZZ__ (tszh, tszl, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQXTNB_Z_ZZ__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38680,8 +38141,7 @@ function decode_UQXTNB_Z_ZZ__ (tszh, tszl, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UQXTNB_Z_ZZ__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38758,8 +38218,7 @@ function decode_SQXTUNB_Z_ZZ__ (tszh, tszl, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQXTUNB_Z_ZZ__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38834,8 +38293,7 @@ function decode_SQXTNT_Z_ZZ__ (tszh, tszl, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQXTNT_Z_ZZ__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38911,8 +38369,7 @@ function decode_UQXTNT_Z_ZZ__ (tszh, tszl, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UQXTNT_Z_ZZ__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -38988,8 +38445,7 @@ function decode_SQXTUNT_Z_ZZ__ (tszh, tszl, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQXTUNT_Z_ZZ__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39052,8 +38508,7 @@ function decode_SMULLT_Z_ZZ__ (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SMULLT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39117,8 +38572,7 @@ function decode_SMULLB_Z_ZZ__ (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SMULLB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39182,8 +38636,7 @@ function decode_UMULLT_Z_ZZ__ (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UMULLT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39247,8 +38700,7 @@ function decode_UMULLB_Z_ZZ__ (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UMULLB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39312,8 +38764,7 @@ function decode_SQDMULLT_Z_ZZ__ (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULLT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39377,8 +38828,7 @@ function decode_SQDMULLB_Z_ZZ__ (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULLB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39442,8 +38892,7 @@ function decode_SMLALT_Z_ZZZ__ (size, Zm, S, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLALT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39508,8 +38957,7 @@ function decode_SMLALB_Z_ZZZ__ (size, Zm, S, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLALB_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39574,8 +39022,7 @@ function decode_UMLALT_Z_ZZZ__ (size, Zm, S, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLALT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39640,8 +39087,7 @@ function decode_UMLALB_Z_ZZZ__ (size, Zm, S, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLALB_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39710,8 +39156,7 @@ function decode_SQDMLALT_Z_ZZZ__ (size, Zm, S, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLALT_Z_ZZZ__(2048, da, esize, m, n, sel1, sel2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39779,8 +39224,7 @@ function decode_SQDMLALB_Z_ZZZ__ (size, Zm, S, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLALB_Z_ZZZ__(2048, da, esize, m, n, sel1, sel2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39844,8 +39288,7 @@ function decode_SMLSLT_Z_ZZZ__ (size, Zm, S, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLSLT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39910,8 +39353,7 @@ function decode_SMLSLB_Z_ZZZ__ (size, Zm, S, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLSLB_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -39976,8 +39418,7 @@ function decode_UMLSLT_Z_ZZZ__ (size, Zm, S, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLSLT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40042,8 +39483,7 @@ function decode_UMLSLB_Z_ZZZ__ (size, Zm, S, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLSLB_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40112,8 +39552,7 @@ function decode_SQDMLSLT_Z_ZZZ__ (size, Zm, S, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLSLT_Z_ZZZ__(2048, da, esize, m, n, sel1, sel2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40181,8 +39620,7 @@ function decode_SQDMLSLB_Z_ZZZ__ (size, Zm, S, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLSLB_Z_ZZZ__(2048, da, esize, m, n, sel1, sel2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40246,8 +39684,7 @@ function decode_SABALT_Z_ZZZ__ (size, Zm, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_SABALT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40311,8 +39748,7 @@ function decode_SABALB_Z_ZZZ__ (size, Zm, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_SABALB_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40376,8 +39812,7 @@ function decode_UABALT_Z_ZZZ__ (size, Zm, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_UABALT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40441,8 +39876,7 @@ function decode_UABALB_Z_ZZZ__ (size, Zm, U, T, Zn, Zda) = {
       },
       2048 => {
           execute_UABALB_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40505,8 +39939,7 @@ function decode_SABA_Z_ZZZ__ (size, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_SABA_Z_ZZZ__(2048, da, esize, m, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40568,8 +40001,7 @@ function decode_UABA_Z_ZZZ__ (size, Zm, U, Zn, Zda) = {
       },
       2048 => {
           execute_UABA_Z_ZZZ__(2048, da, esize, m, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40631,8 +40063,7 @@ function decode_SADDWT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SADDWT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40696,8 +40127,7 @@ function decode_SADDWB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SADDWB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40761,8 +40191,7 @@ function decode_UADDWT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UADDWT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40826,8 +40255,7 @@ function decode_UADDWB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UADDWB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40891,8 +40319,7 @@ function decode_SSUBWT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SSUBWT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -40956,8 +40383,7 @@ function decode_SSUBWB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SSUBWB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41021,8 +40447,7 @@ function decode_USUBWT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_USUBWT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41086,8 +40511,7 @@ function decode_USUBWB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_USUBWB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41148,8 +40572,7 @@ function decode_PMUL_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_PMUL_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41223,8 +40646,7 @@ function decode_PMULLT_Z_ZZ__ (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_PMULLT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41300,8 +40722,7 @@ function decode_PMULLB_Z_ZZ__ (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_PMULLB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41365,8 +40786,7 @@ function decode_PMULLT_Z_ZZ_Q (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_PMULLT_Z_ZZ_Q(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41430,8 +40850,7 @@ function decode_PMULLB_Z_ZZ_Q (size, Zm, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_PMULLB_Z_ZZ_Q(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41508,8 +40927,7 @@ function decode_SQSHL_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SQSHL_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41588,8 +41006,7 @@ function decode_UQSHL_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UQSHL_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41668,8 +41085,7 @@ function decode_SRSHL_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SRSHL_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41748,8 +41164,7 @@ function decode_URSHL_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_URSHL_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41828,8 +41243,7 @@ function decode_SQRSHL_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SQRSHL_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41908,8 +41322,7 @@ function decode_UQRSHL_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UQRSHL_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -41988,8 +41401,7 @@ function decode_SQSHLR_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SQSHLR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42068,8 +41480,7 @@ function decode_UQSHLR_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UQSHLR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42148,8 +41559,7 @@ function decode_SRSHLR_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SRSHLR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42228,8 +41638,7 @@ function decode_URSHLR_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_URSHLR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42308,8 +41717,7 @@ function decode_SQRSHLR_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SQRSHLR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42388,8 +41796,7 @@ function decode_UQRSHLR_Z_P_ZZ__ (size, Q, R, N, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UQRSHLR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42457,8 +41864,7 @@ function decode_ADDHNB_Z_ZZ__ (size, Zm, S, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_ADDHNB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42524,8 +41930,7 @@ function decode_ADDHNT_Z_ZZ__ (size, Zm, S, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_ADDHNT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42592,8 +41997,7 @@ function decode_SUBHNB_Z_ZZ__ (size, Zm, S, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SUBHNB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42659,8 +42063,7 @@ function decode_SUBHNT_Z_ZZ__ (size, Zm, S, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_SUBHNT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42727,8 +42130,7 @@ function decode_RADDHNB_Z_ZZ__ (size, Zm, S, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_RADDHNB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42794,8 +42196,7 @@ function decode_RADDHNT_Z_ZZ__ (size, Zm, S, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_RADDHNT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42862,8 +42263,7 @@ function decode_RSUBHNB_Z_ZZ__ (size, Zm, S, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_RSUBHNB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42929,8 +42329,7 @@ function decode_RSUBHNT_Z_ZZ__ (size, Zm, S, R, T, Zn, Zd) = {
       },
       2048 => {
           execute_RSUBHNT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -42995,8 +42394,7 @@ function decode_SABDLB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SABDLB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43061,8 +42459,7 @@ function decode_SABDLT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SABDLT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43127,8 +42524,7 @@ function decode_UABDLB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UABDLB_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43193,8 +42589,7 @@ function decode_UABDLT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UABDLT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43262,8 +42657,7 @@ function decode_SADDLB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SADDLB_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43331,8 +42725,7 @@ function decode_SADDLT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SADDLT_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43400,8 +42793,7 @@ function decode_SSUBLB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SSUBLB_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43469,8 +42861,7 @@ function decode_SSUBLT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_SSUBLT_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43538,8 +42929,7 @@ function decode_UADDLB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UADDLB_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43607,8 +42997,7 @@ function decode_UADDLT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_UADDLT_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43676,8 +43065,7 @@ function decode_USUBLB_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_USUBLB_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43745,8 +43133,7 @@ function decode_USUBLT_Z_ZZ__ (size, Zm, S, U, T, Zn, Zd) = {
       },
       2048 => {
           execute_USUBLT_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43814,8 +43201,7 @@ function decode_SADDLBT_Z_ZZ__ (size, Zm, S, tb, Zn, Zd) = {
       },
       2048 => {
           execute_SADDLBT_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43882,8 +43268,7 @@ function decode_SSUBLBT_Z_ZZ__ (size, Zm, S, tb, Zn, Zd) = {
       },
       2048 => {
           execute_SSUBLBT_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -43950,8 +43335,7 @@ function decode_SSUBLTB_Z_ZZ__ (size, Zm, S, tb, Zn, Zd) = {
       },
       2048 => {
           execute_SSUBLTB_Z_ZZ__(2048, d, esize, m, n, sel1, sel2, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44026,8 +43410,7 @@ function decode_CADD_Z_ZZ__ (size, rot, Zm, Zdn) = {
       },
       2048 => {
           execute_CADD_Z_ZZ__(2048, dn, esize, m, sub_i, sub_r)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44100,8 +43483,7 @@ function decode_SQCADD_Z_ZZ__ (size, rot, Zm, Zdn) = {
       },
       2048 => {
           execute_SQCADD_Z_ZZ__(2048, dn, esize, m, sub_i, sub_r)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44179,8 +43561,7 @@ function decode_CMLA_Z_ZZZ__ (size, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_CMLA_Z_ZZZ__(2048, da, esize, m, n, sel_a, sel_b, sub_i, sub_r)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44263,8 +43644,7 @@ function decode_CMLA_Z_ZZZi_H (size, i2, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_CMLA_Z_ZZZi_H(2048, da, esize, index, m, n, sel_a, sel_b, sub_i, sub_r)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44348,8 +43728,7 @@ function decode_CMLA_Z_ZZZi_S (size, i1, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_CMLA_Z_ZZZi_S(2048, da, esize, index, m, n, sel_a, sel_b, sub_i, sub_r)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44435,8 +43814,7 @@ function decode_SQRDCMLAH_Z_ZZZ__ (size, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDCMLAH_Z_ZZZ__(2048, da, esize, m, n, sel_a, sel_b, sub_i, sub_r)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44525,8 +43903,7 @@ function decode_SQRDCMLAH_Z_ZZZi_H (size, i2, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDCMLAH_Z_ZZZi_H(2048, da, esize, index, m, n, sel_a, sel_b, sub_i, sub_r)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44616,8 +43993,7 @@ function decode_SQRDCMLAH_Z_ZZZi_S (size, i1, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDCMLAH_Z_ZZZi_S(2048, da, esize, index, m, n, sel_a, sel_b, sub_i, sub_r)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44678,8 +44054,7 @@ function decode_MUL_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_MUL_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44743,8 +44118,7 @@ function decode_MUL_Z_ZZi_H (i3h, i3l, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_MUL_Z_ZZi_H(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44809,8 +44183,7 @@ function decode_MUL_Z_ZZi_S (size, i2, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_MUL_Z_ZZi_S(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44875,8 +44248,7 @@ function decode_MUL_Z_ZZi_D (size, i1, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_MUL_Z_ZZi_D(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -44941,8 +44313,7 @@ function decode_MLA_Z_ZZZi_H (i3h, i3l, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_MLA_Z_ZZZi_H(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45008,8 +44379,7 @@ function decode_MLA_Z_ZZZi_S (size, i2, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_MLA_Z_ZZZi_S(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45075,8 +44445,7 @@ function decode_MLA_Z_ZZZi_D (size, i1, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_MLA_Z_ZZZi_D(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45142,8 +44511,7 @@ function decode_MLS_Z_ZZZi_H (i3h, i3l, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_MLS_Z_ZZZi_H(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45209,8 +44577,7 @@ function decode_MLS_Z_ZZZi_S (size, i2, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_MLS_Z_ZZZi_S(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45276,8 +44643,7 @@ function decode_MLS_Z_ZZZi_D (size, i1, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_MLS_Z_ZZZi_D(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45343,8 +44709,7 @@ function decode_SMULLB_Z_ZZi_S (size, i3h, Zm, U, i3l, T, Zn, Zd) = {
       },
       2048 => {
           execute_SMULLB_Z_ZZi_S(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45412,8 +44777,7 @@ function decode_SMULLB_Z_ZZi_D (size, i2h, Zm, U, i2l, T, Zn, Zd) = {
       },
       2048 => {
           execute_SMULLB_Z_ZZi_D(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45481,8 +44845,7 @@ function decode_SMULLT_Z_ZZi_S (size, i3h, Zm, U, i3l, T, Zn, Zd) = {
       },
       2048 => {
           execute_SMULLT_Z_ZZi_S(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45550,8 +44913,7 @@ function decode_SMULLT_Z_ZZi_D (size, i2h, Zm, U, i2l, T, Zn, Zd) = {
       },
       2048 => {
           execute_SMULLT_Z_ZZi_D(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45619,8 +44981,7 @@ function decode_UMULLB_Z_ZZi_S (size, i3h, Zm, U, i3l, T, Zn, Zd) = {
       },
       2048 => {
           execute_UMULLB_Z_ZZi_S(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45688,8 +45049,7 @@ function decode_UMULLB_Z_ZZi_D (size, i2h, Zm, U, i2l, T, Zn, Zd) = {
       },
       2048 => {
           execute_UMULLB_Z_ZZi_D(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45757,8 +45117,7 @@ function decode_UMULLT_Z_ZZi_S (size, i3h, Zm, U, i3l, T, Zn, Zd) = {
       },
       2048 => {
           execute_UMULLT_Z_ZZi_S(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45826,8 +45185,7 @@ function decode_UMULLT_Z_ZZi_D (size, i2h, Zm, U, i2l, T, Zn, Zd) = {
       },
       2048 => {
           execute_UMULLT_Z_ZZi_D(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45895,8 +45253,7 @@ function decode_SMLALB_Z_ZZZi_S (size, i3h, Zm, S, U, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLALB_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -45965,8 +45322,7 @@ function decode_SMLALB_Z_ZZZi_D (size, i2h, Zm, S, U, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLALB_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46035,8 +45391,7 @@ function decode_SMLALT_Z_ZZZi_S (size, i3h, Zm, S, U, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLALT_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46105,8 +45460,7 @@ function decode_SMLALT_Z_ZZZi_D (size, i2h, Zm, S, U, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLALT_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46175,8 +45529,7 @@ function decode_UMLALB_Z_ZZZi_S (size, i3h, Zm, S, U, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLALB_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46245,8 +45598,7 @@ function decode_UMLALB_Z_ZZZi_D (size, i2h, Zm, S, U, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLALB_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46315,8 +45667,7 @@ function decode_UMLALT_Z_ZZZi_S (size, i3h, Zm, S, U, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLALT_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46385,8 +45736,7 @@ function decode_UMLALT_Z_ZZZi_D (size, i2h, Zm, S, U, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLALT_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46455,8 +45805,7 @@ function decode_SMLSLB_Z_ZZZi_S (size, i3h, Zm, S, U, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLSLB_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46525,8 +45874,7 @@ function decode_SMLSLB_Z_ZZZi_D (size, i2h, Zm, S, U, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLSLB_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46595,8 +45943,7 @@ function decode_SMLSLT_Z_ZZZi_S (size, i3h, Zm, S, U, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLSLT_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46665,8 +46012,7 @@ function decode_SMLSLT_Z_ZZZi_D (size, i2h, Zm, S, U, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SMLSLT_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46735,8 +46081,7 @@ function decode_UMLSLB_Z_ZZZi_S (size, i3h, Zm, S, U, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLSLB_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46805,8 +46150,7 @@ function decode_UMLSLB_Z_ZZZi_D (size, i2h, Zm, S, U, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLSLB_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46875,8 +46219,7 @@ function decode_UMLSLT_Z_ZZZi_S (size, i3h, Zm, S, U, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLSLT_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -46945,8 +46288,7 @@ function decode_UMLSLT_Z_ZZZi_D (size, i2h, Zm, S, U, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_UMLSLT_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47015,8 +46357,7 @@ function decode_SQDMULLB_Z_ZZi_S (size, i3h, Zm, i3l, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULLB_Z_ZZi_S(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47083,8 +46424,7 @@ function decode_SQDMULLB_Z_ZZi_D (size, i2h, Zm, i2l, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULLB_Z_ZZi_D(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47151,8 +46491,7 @@ function decode_SQDMULLT_Z_ZZi_S (size, i3h, Zm, i3l, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULLT_Z_ZZi_S(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47219,8 +46558,7 @@ function decode_SQDMULLT_Z_ZZi_D (size, i2h, Zm, i2l, T, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULLT_Z_ZZi_D(2048, d, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47289,8 +46627,7 @@ function decode_SQDMLALB_Z_ZZZi_S (size, i3h, Zm, S, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLALB_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47360,8 +46697,7 @@ function decode_SQDMLALB_Z_ZZZi_D (size, i2h, Zm, S, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLALB_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47431,8 +46767,7 @@ function decode_SQDMLALT_Z_ZZZi_S (size, i3h, Zm, S, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLALT_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47502,8 +46837,7 @@ function decode_SQDMLALT_Z_ZZZi_D (size, i2h, Zm, S, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLALT_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47573,8 +46907,7 @@ function decode_SQDMLSLB_Z_ZZZi_S (size, i3h, Zm, S, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLSLB_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47644,8 +46977,7 @@ function decode_SQDMLSLB_Z_ZZZi_D (size, i2h, Zm, S, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLSLB_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47715,8 +47047,7 @@ function decode_SQDMLSLT_Z_ZZZi_S (size, i3h, Zm, S, i3l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLSLT_Z_ZZZi_S(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47786,8 +47117,7 @@ function decode_SQDMLSLT_Z_ZZZi_D (size, i2h, Zm, S, i2l, T, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLSLT_Z_ZZZi_D(2048, da, esize, index, m, n, sel)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47857,8 +47187,7 @@ function decode_SQDMLALBT_Z_ZZZ__ (size, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLALBT_Z_ZZZ__(2048, da, esize, m, n, sel1, sel2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47925,8 +47254,7 @@ function decode_SQDMLSLBT_Z_ZZZ__ (size, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQDMLSLBT_Z_ZZZ__(2048, da, esize, m, n, sel1, sel2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -47990,8 +47318,7 @@ function decode_SQRDMULH_Z_ZZi_H (i3h, i3l, Zm, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQRDMULH_Z_ZZi_H(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48056,8 +47383,7 @@ function decode_SQRDMULH_Z_ZZi_S (size, i2, Zm, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQRDMULH_Z_ZZi_S(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48122,8 +47448,7 @@ function decode_SQRDMULH_Z_ZZi_D (size, i1, Zm, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQRDMULH_Z_ZZi_D(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48190,8 +47515,7 @@ function decode_SQRDMLAH_Z_ZZZi_H (i3h, i3l, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDMLAH_Z_ZZZi_H(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48258,8 +47582,7 @@ function decode_SQRDMLAH_Z_ZZZi_S (size, i2, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDMLAH_Z_ZZZi_S(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48326,8 +47649,7 @@ function decode_SQRDMLAH_Z_ZZZi_D (size, i1, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDMLAH_Z_ZZZi_D(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48394,8 +47716,7 @@ function decode_SQRDMLSH_Z_ZZZi_H (i3h, i3l, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDMLSH_Z_ZZZi_H(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48462,8 +47783,7 @@ function decode_SQRDMLSH_Z_ZZZi_S (size, i2, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDMLSH_Z_ZZZi_S(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48530,8 +47850,7 @@ function decode_SQRDMLSH_Z_ZZZi_D (size, i1, Zm, S, Zn, Zda) = {
       },
       2048 => {
           execute_SQRDMLSH_Z_ZZZi_D(2048, da, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48601,8 +47920,7 @@ function decode_SHADD_Z_P_ZZ__ (size, R, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SHADD_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48673,8 +47991,7 @@ function decode_SHSUB_Z_P_ZZ__ (size, R, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SHSUB_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48745,8 +48062,7 @@ function decode_SHSUBR_Z_P_ZZ__ (size, R, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SHSUBR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48817,8 +48133,7 @@ function decode_SRHADD_Z_P_ZZ__ (size, R, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SRHADD_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48889,8 +48204,7 @@ function decode_UHADD_Z_P_ZZ__ (size, R, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UHADD_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -48961,8 +48275,7 @@ function decode_UHSUB_Z_P_ZZ__ (size, R, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UHSUB_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49033,8 +48346,7 @@ function decode_UHSUBR_Z_P_ZZ__ (size, R, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UHSUBR_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49105,8 +48417,7 @@ function decode_URHADD_Z_P_ZZ__ (size, R, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_URHADD_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49178,8 +48489,7 @@ function decode_SQADD_Z_P_ZZ__ (size, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SQADD_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49250,8 +48560,7 @@ function decode_UQADD_Z_P_ZZ__ (size, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UQADD_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49322,8 +48631,7 @@ function decode_SQSUB_Z_P_ZZ__ (size, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SQSUB_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49394,8 +48702,7 @@ function decode_UQSUB_Z_P_ZZ__ (size, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UQSUB_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49466,8 +48773,7 @@ function decode_SQSUBR_Z_P_ZZ__ (size, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SQSUBR_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49538,8 +48844,7 @@ function decode_UQSUBR_Z_P_ZZ__ (size, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_UQSUBR_Z_P_ZZ__(2048, dn, esize, g, m, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49608,8 +48913,7 @@ function decode_SUQADD_Z_P_ZZ__ (size, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_SUQADD_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49678,8 +48982,7 @@ function decode_USQADD_Z_P_ZZ__ (size, S, U, Pg, Zm, Zdn) = {
       },
       2048 => {
           execute_USQADD_Z_P_ZZ__(2048, dn, esize, g, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -49762,8 +49065,7 @@ function decode_SLI_Z_ZZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_SLI_Z_ZZI__(2048, d, 8, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -49782,8 +49084,7 @@ function decode_SLI_Z_ZZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_SLI_Z_ZZI__(2048, d, 16, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -49802,8 +49103,7 @@ function decode_SLI_Z_ZZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_SLI_Z_ZZI__(2048, d, 32, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -49822,8 +49122,7 @@ function decode_SLI_Z_ZZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_SLI_Z_ZZI__(2048, d, 64, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -49910,8 +49209,7 @@ function decode_SRI_Z_ZZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_SRI_Z_ZZI__(2048, d, 8, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -49930,8 +49228,7 @@ function decode_SRI_Z_ZZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_SRI_Z_ZZI__(2048, d, 16, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -49950,8 +49247,7 @@ function decode_SRI_Z_ZZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_SRI_Z_ZZI__(2048, d, 32, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -49970,8 +49266,7 @@ function decode_SRI_Z_ZZI__ (tszh, tszl, imm3, Zn, Zd) = {
             },
             2048 => {
                 execute_SRI_Z_ZZI__(2048, d, 64, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -50038,8 +49333,7 @@ function decode_TBX_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_TBX_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50106,8 +49400,7 @@ function decode_URECPE_Z_P_Z__ (size, Q, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_URECPE_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50175,8 +49468,7 @@ function decode_URSQRTE_Z_P_Z__ (size, Q, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_URSQRTE_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50268,8 +49560,7 @@ function decode_MATCH_P_P_ZZ__ (size, Zm, Pg, Zn, Pd) = {
       },
       2048 => {
           execute_MATCH_P_P_ZZ__(2048, d, esize, g, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50361,8 +49652,7 @@ function decode_NMATCH_P_P_ZZ__ (size, Zm, Pg, Zn, Pd) = {
       },
       2048 => {
           execute_NMATCH_P_P_ZZ__(2048, d, esize, g, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50449,8 +49739,7 @@ function decode_HISTCNT_Z_P_ZZ__ (size, Zm, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_HISTCNT_Z_P_ZZ__(2048, d, esize, g, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50525,8 +49814,7 @@ function decode_HISTSEG_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_HISTSEG_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50593,8 +49881,7 @@ function decode_WHILEWR_P_RR__ (size, Rm, Rn, rw, Pd) = {
       },
       2048 => {
           execute_WHILEWR_P_RR__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50662,8 +49949,7 @@ function decode_WHILERW_P_RR__ (size, Rm, Rn, rw, Pd) = {
       },
       2048 => {
           execute_WHILERW_P_RR__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50720,8 +50006,7 @@ function decode_BDEP_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BDEP_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50777,8 +50062,7 @@ function decode_BEXT_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BEXT_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50834,8 +50118,7 @@ function decode_BGRP_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_BGRP_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50895,8 +50178,7 @@ function decode_EORBT_Z_ZZ__ (size, Zm, tb, Zn, Zd) = {
       },
       2048 => {
           execute_EORBT_Z_ZZ__(2048, d, esize, m, n, sel1, sel2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -50957,8 +50239,7 @@ function decode_EORTB_Z_ZZ__ (size, Zm, tb, Zn, Zd) = {
       },
       2048 => {
           execute_EORTB_Z_ZZ__(2048, d, esize, m, n, sel1, sel2)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51037,8 +50318,7 @@ function decode_CDOT_Z_ZZZ__ (size, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_CDOT_Z_ZZZ__(2048, da, esize, m, n, sel_a, sel_b, sub_i)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51115,8 +50395,7 @@ function decode_CDOT_Z_ZZZi_S (size, i2, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_CDOT_Z_ZZZi_S(2048, da, esize, index, m, n, sel_a, sel_b, sub_i)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51194,8 +50473,7 @@ function decode_CDOT_Z_ZZZi_D (size, i1, Zm, rot, Zn, Zda) = {
       },
       2048 => {
           execute_CDOT_Z_ZZZi_D(2048, da, esize, index, m, n, sel_a, sel_b, sub_i)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51263,8 +50541,7 @@ function decode_SMMLA_Z_ZZZ__ (uns, Zm, Zn, Zda) = {
       },
       2048 => {
           execute_SMMLA_Z_ZZZ__(2048, da, m, n, op1_unsigned, op2_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51330,8 +50607,7 @@ function decode_UMMLA_Z_ZZZ__ (uns, Zm, Zn, Zda) = {
       },
       2048 => {
           execute_UMMLA_Z_ZZZ__(2048, da, m, n, op1_unsigned, op2_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51397,8 +50673,7 @@ function decode_USMMLA_Z_ZZZ__ (uns, Zm, Zn, Zda) = {
       },
       2048 => {
           execute_USMMLA_Z_ZZZ__(2048, da, m, n, op1_unsigned, op2_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51461,8 +50736,7 @@ function decode_SQDMULH_Z_ZZi_H (i3h, i3l, Zm, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULH_Z_ZZi_H(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51527,8 +50801,7 @@ function decode_SQDMULH_Z_ZZi_S (size, i2, Zm, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULH_Z_ZZi_S(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51593,8 +50866,7 @@ function decode_SQDMULH_Z_ZZi_D (size, i1, Zm, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQDMULH_Z_ZZi_D(2048, d, esize, index, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -51674,8 +50946,7 @@ function decode_SRSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_SRSRA_Z_ZI__(2048, da, 8, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -51694,8 +50965,7 @@ function decode_SRSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_SRSRA_Z_ZI__(2048, da, 16, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -51714,8 +50984,7 @@ function decode_SRSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_SRSRA_Z_ZI__(2048, da, 32, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -51734,8 +51003,7 @@ function decode_SRSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_SRSRA_Z_ZI__(2048, da, 64, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -51821,8 +51089,7 @@ function decode_SSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_SSRA_Z_ZI__(2048, da, 8, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -51841,8 +51108,7 @@ function decode_SSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_SSRA_Z_ZI__(2048, da, 16, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -51861,8 +51127,7 @@ function decode_SSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_SSRA_Z_ZI__(2048, da, 32, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -51881,8 +51146,7 @@ function decode_SSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_SSRA_Z_ZI__(2048, da, 64, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -51968,8 +51232,7 @@ function decode_URSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_URSRA_Z_ZI__(2048, da, 8, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -51988,8 +51251,7 @@ function decode_URSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_URSRA_Z_ZI__(2048, da, 16, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -52008,8 +51270,7 @@ function decode_URSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_URSRA_Z_ZI__(2048, da, 32, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -52028,8 +51289,7 @@ function decode_URSRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_URSRA_Z_ZI__(2048, da, 64, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -52115,8 +51375,7 @@ function decode_USRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_USRA_Z_ZI__(2048, da, 8, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -52135,8 +51394,7 @@ function decode_USRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_USRA_Z_ZI__(2048, da, 16, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -52155,8 +51413,7 @@ function decode_USRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_USRA_Z_ZI__(2048, da, 32, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -52175,8 +51432,7 @@ function decode_USRA_Z_ZI__ (tszh, tszl, imm3, R, U, Zn, Zda) = {
             },
             2048 => {
                 execute_USRA_Z_ZI__(2048, da, 64, n, shift)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -52238,8 +51494,7 @@ function decode_AESD_Z_ZZ__ (size, Zm, Zdn) = {
       },
       2048 => {
           execute_AESD_Z_ZZ__(2048, dn, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52292,8 +51547,7 @@ function decode_AESE_Z_ZZ__ (size, Zm, Zdn) = {
       },
       2048 => {
           execute_AESE_Z_ZZ__(2048, dn, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52344,8 +51598,7 @@ function decode_AESIMC_Z_Z__ (size, Zdn) = {
       },
       2048 => {
           execute_AESIMC_Z_Z__(2048, dn)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52395,8 +51648,7 @@ function decode_AESMC_Z_Z__ (size, Zdn) = {
       },
       2048 => {
           execute_AESMC_Z_Z__(2048, dn)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52455,8 +51707,7 @@ function decode_RAX1_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_RAX1_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52528,8 +51779,7 @@ function decode_SM4E_Z_ZZ__ (size, Zm, Zdn) = {
       },
       2048 => {
           execute_SM4E_Z_ZZ__(2048, dn, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52601,8 +51851,7 @@ function decode_SM4EKEY_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_SM4EKEY_Z_ZZ__(2048, d, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52682,8 +51931,7 @@ function decode_XAR_Z_ZZI__ (tszh, tszl, imm3, Zm, Zdn) = {
             },
             2048 => {
                 execute_XAR_Z_ZZI__(2048, dn, 8, m, rot)
-            },
-            _ => ()
+            }
           }
       },
       16 => {
@@ -52702,8 +51950,7 @@ function decode_XAR_Z_ZZI__ (tszh, tszl, imm3, Zm, Zdn) = {
             },
             2048 => {
                 execute_XAR_Z_ZZI__(2048, dn, 16, m, rot)
-            },
-            _ => ()
+            }
           }
       },
       32 => {
@@ -52722,8 +51969,7 @@ function decode_XAR_Z_ZZI__ (tszh, tszl, imm3, Zm, Zdn) = {
             },
             2048 => {
                 execute_XAR_Z_ZZI__(2048, dn, 32, m, rot)
-            },
-            _ => ()
+            }
           }
       },
       64 => {
@@ -52742,8 +51988,7 @@ function decode_XAR_Z_ZZI__ (tszh, tszl, imm3, Zm, Zdn) = {
             },
             2048 => {
                 execute_XAR_Z_ZZI__(2048, dn, 64, m, rot)
-            },
-            _ => ()
+            }
           }
       },
       _ => {
@@ -52800,8 +52045,7 @@ function decode_BCAX_Z_ZZZ__ (Zm, Zk, Zdn) = {
       },
       2048 => {
           execute_BCAX_Z_ZZZ__(2048, dn, k, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52851,8 +52095,7 @@ function decode_EOR3_Z_ZZZ__ (Zm, Zk, Zdn) = {
       },
       2048 => {
           execute_EOR3_Z_ZZZ__(2048, dn, k, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52902,8 +52145,7 @@ function decode_BSL_Z_ZZZ__ (Zm, Zk, Zdn) = {
       },
       2048 => {
           execute_BSL_Z_ZZZ__(2048, dn, k, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -52953,8 +52195,7 @@ function decode_BSL1N_Z_ZZZ__ (Zm, Zk, Zdn) = {
       },
       2048 => {
           execute_BSL1N_Z_ZZZ__(2048, dn, k, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53004,8 +52245,7 @@ function decode_BSL2N_Z_ZZZ__ (Zm, Zk, Zdn) = {
       },
       2048 => {
           execute_BSL2N_Z_ZZZ__(2048, dn, k, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53055,8 +52295,7 @@ function decode_NBSL_Z_ZZZ__ (Zm, Zk, Zdn) = {
       },
       2048 => {
           execute_NBSL_Z_ZZZ__(2048, dn, k, m)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53120,8 +52359,7 @@ function decode_ADCLB_Z_ZZZ__ (sz, Zm, T, Zn, Zda) = {
       },
       2048 => {
           execute_ADCLB_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53187,8 +52425,7 @@ function decode_ADCLT_Z_ZZZ__ (sz, Zm, T, Zn, Zda) = {
       },
       2048 => {
           execute_ADCLT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53254,8 +52491,7 @@ function decode_SBCLB_Z_ZZZ__ (sz, Zm, T, Zn, Zda) = {
       },
       2048 => {
           execute_SBCLB_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53321,8 +52557,7 @@ function decode_SBCLT_Z_ZZZ__ (sz, Zm, T, Zn, Zda) = {
       },
       2048 => {
           execute_SBCLT_Z_ZZZ__(2048, da, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53383,8 +52618,7 @@ function decode_SMULH_Z_ZZ__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_SMULH_Z_ZZ__(2048, d, esize, m, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53445,8 +52679,7 @@ function decode_UMULH_Z_ZZ__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_UMULH_Z_ZZ__(2048, d, esize, m, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53508,8 +52741,7 @@ function decode_SCLAMP_Z_ZZ__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_SCLAMP_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53571,8 +52803,7 @@ function decode_UCLAMP_Z_ZZ__ (size, Zm, U, Zn, Zd) = {
       },
       2048 => {
           execute_UCLAMP_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53638,8 +52869,7 @@ function decode_REVD_Z_P_Z__ (size, Pg, Zn, Zd) = {
       },
       2048 => {
           execute_REVD_Z_P_Z__(2048, d, esize, g, n, swsize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53726,8 +52956,7 @@ function decode_PSEL_P_PPi__ (i1, tszh, tszl, Rv, Pn, S, Pm, Pd) = {
       },
       2048 => {
           execute_PSEL_P_PPi__(2048, d, esize, imm, m, n, v)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53768,7 +52997,7 @@ function execute_WHILELO_PP_RR__ (VL, d0, d1, esize, m, n, op, rsize, is_unsigne
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELO_PP_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -53810,8 +53039,7 @@ function decode_WHILELO_PP_RR__ (size, Rm, U, lt, Rn, Pd, eq) = {
       },
       2048 => {
           execute_WHILELO_PP_RR__(2048, d0, d1, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53851,7 +53079,7 @@ function execute_WHILELS_PP_RR__ (VL, d0, d1, esize, m, n, op, rsize, is_unsigne
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELS_PP_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -53893,8 +53121,7 @@ function decode_WHILELS_PP_RR__ (size, Rm, U, lt, Rn, Pd, eq) = {
       },
       2048 => {
           execute_WHILELS_PP_RR__(2048, d0, d1, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -53934,7 +53161,7 @@ function execute_WHILELT_PP_RR__ (VL, d0, d1, esize, m, n, op, rsize, is_unsigne
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELT_PP_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -53976,8 +53203,7 @@ function decode_WHILELT_PP_RR__ (size, Rm, U, lt, Rn, Pd, eq) = {
       },
       2048 => {
           execute_WHILELT_PP_RR__(2048, d0, d1, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54017,7 +53243,7 @@ function execute_WHILELE_PP_RR__ (VL, d0, d1, esize, m, n, op, rsize, is_unsigne
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELE_PP_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -54059,8 +53285,7 @@ function decode_WHILELE_PP_RR__ (size, Rm, U, lt, Rn, Pd, eq) = {
       },
       2048 => {
           execute_WHILELE_PP_RR__(2048, d0, d1, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54100,7 +53325,7 @@ function execute_WHILEHI_PP_RR__ (VL, d0, d1, esize, m, n, op, rsize, is_unsigne
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEHI_PP_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -54142,8 +53367,7 @@ function decode_WHILEHI_PP_RR__ (size, Rm, U, lt, Rn, Pd, eq) = {
       },
       2048 => {
           execute_WHILEHI_PP_RR__(2048, d0, d1, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54183,7 +53407,7 @@ function execute_WHILEHS_PP_RR__ (VL, d0, d1, esize, m, n, op, rsize, is_unsigne
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEHS_PP_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -54225,8 +53449,7 @@ function decode_WHILEHS_PP_RR__ (size, Rm, U, lt, Rn, Pd, eq) = {
       },
       2048 => {
           execute_WHILEHS_PP_RR__(2048, d0, d1, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54266,7 +53489,7 @@ function execute_WHILEGT_PP_RR__ (VL, d0, d1, esize, m, n, op, rsize, is_unsigne
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEGT_PP_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -54308,8 +53531,7 @@ function decode_WHILEGT_PP_RR__ (size, Rm, U, lt, Rn, Pd, eq) = {
       },
       2048 => {
           execute_WHILEGT_PP_RR__(2048, d0, d1, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54349,7 +53571,7 @@ function execute_WHILEGE_PP_RR__ (VL, d0, d1, esize, m, n, op, rsize, is_unsigne
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEGE_PP_RR__")
         };
         last = last & cond;
         let pbit : bits(1) = if last then 0b1 else 0b0;
@@ -54391,8 +53613,7 @@ function decode_WHILEGE_PP_RR__ (size, Rm, U, lt, Rn, Pd, eq) = {
       },
       2048 => {
           execute_WHILEGE_PP_RR__(2048, d0, d1, esize, m, n, op, rsize, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54455,8 +53676,7 @@ function decode_SQRSHRN_Z_MZ2__ (tszh, tszl, imm4, U, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQRSHRN_Z_MZ2__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54519,8 +53739,7 @@ function decode_SQRSHRUN_Z_MZ2__ (tszh, tszl, imm4, U, R, Zn, Zd) = {
       },
       2048 => {
           execute_SQRSHRUN_Z_MZ2__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54583,8 +53802,7 @@ function decode_UQRSHRN_Z_MZ2__ (tszh, tszl, imm4, U, R, Zn, Zd) = {
       },
       2048 => {
           execute_UQRSHRN_Z_MZ2__(2048, d, esize, n, shift)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54645,8 +53863,7 @@ function decode_SQCVTN_Z_MZ2__ (tszh, tszl, U, Zn, Zd) = {
       },
       2048 => {
           execute_SQCVTN_Z_MZ2__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54705,8 +53922,7 @@ function decode_SQCVTUN_Z_MZ2__ (tszh, tszl, Zn, Zd) = {
       },
       2048 => {
           execute_SQCVTUN_Z_MZ2__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54764,8 +53980,7 @@ function decode_UQCVTN_Z_MZ2__ (tszh, tszl, U, Zn, Zd) = {
       },
       2048 => {
           execute_UQCVTN_Z_MZ2__(2048, d, esize, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54849,8 +54064,7 @@ function decode_DUPQ_Z_Zi__ (i1, tsz, Zn, Zd) = {
       },
       2048 => {
           execute_DUPQ_Z_Zi__(2048, d, esize, index, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54908,8 +54122,7 @@ function decode_EXTQ_Z_ZI_Des (imm4, Zm, Zdn) = {
       },
       2048 => {
           execute_EXTQ_Z_ZI_Des(2048, dn, m, position)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -54973,8 +54186,7 @@ function decode_TBLQ_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_TBLQ_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55038,8 +54250,7 @@ function decode_TBXQ_Z_ZZ__ (size, Zm, Zn, Zd) = {
       },
       2048 => {
           execute_TBXQ_Z_ZZ__(2048, d, esize, m, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55104,8 +54315,7 @@ function decode_UZPQ1_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_UZPQ1_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55171,8 +54381,7 @@ function decode_UZPQ2_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_UZPQ2_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55237,8 +54446,7 @@ function decode_ZIPQ1_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_ZIPQ1_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55303,8 +54511,7 @@ function decode_ZIPQ2_Z_ZZ__ (size, Zm, H, Zn, Zd) = {
       },
       2048 => {
           execute_ZIPQ2_Z_ZZ__(2048, d, esize, m, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55376,8 +54583,7 @@ function decode_ANDQV_Z_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_ANDQV_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55448,8 +54654,7 @@ function decode_EORQV_Z_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_EORQV_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55520,8 +54725,7 @@ function decode_ORQV_Z_P_Z__ (size, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_ORQV_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55593,8 +54797,7 @@ function decode_ADDQV_Z_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_ADDQV_Z_P_Z__(2048, d, esize, g, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55667,8 +54870,7 @@ function decode_SMAXQV_Z_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_SMAXQV_Z_P_Z__(2048, d, esize, g, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55741,8 +54943,7 @@ function decode_UMAXQV_Z_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_UMAXQV_Z_P_Z__(2048, d, esize, g, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55815,8 +55016,7 @@ function decode_SMINQV_Z_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_SMINQV_Z_P_Z__(2048, d, esize, g, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55889,8 +55089,7 @@ function decode_UMINQV_Z_P_Z__ (size, U, Pg, Zn, Vd) = {
       },
       2048 => {
           execute_UMINQV_Z_P_Z__(2048, d, esize, g, n, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -55952,8 +55151,7 @@ function decode_PMOV_Z_PI_B (Pn, Zd) = {
       },
       2048 => {
           execute_PMOV_Z_PI_B(2048, d, esize, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56012,8 +55210,7 @@ function decode_PMOV_Z_PI_H (i1, Pn, Zd) = {
       },
       2048 => {
           execute_PMOV_Z_PI_H(2048, d, esize, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56073,8 +55270,7 @@ function decode_PMOV_Z_PI_S (i2, Pn, Zd) = {
       },
       2048 => {
           execute_PMOV_Z_PI_S(2048, d, esize, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56134,8 +55330,7 @@ function decode_PMOV_Z_PI_D (i3h, i3l, Pn, Zd) = {
       },
       2048 => {
           execute_PMOV_Z_PI_D(2048, d, esize, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56192,8 +55387,7 @@ function decode_PMOV_P_ZI_B (Zn, Pd) = {
       },
       2048 => {
           execute_PMOV_P_ZI_B(2048, d, esize, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56248,8 +55442,7 @@ function decode_PMOV_P_ZI_H (i1, Zn, Pd) = {
       },
       2048 => {
           execute_PMOV_P_ZI_H(2048, d, esize, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56305,8 +55498,7 @@ function decode_PMOV_P_ZI_S (i2, Zn, Pd) = {
       },
       2048 => {
           execute_PMOV_P_ZI_S(2048, d, esize, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56362,8 +55554,7 @@ function decode_PMOV_P_ZI_D (i3h, i3l, Zn, Pd) = {
       },
       2048 => {
           execute_PMOV_P_ZI_D(2048, d, esize, imm, n)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56426,8 +55617,7 @@ function decode_PEXT_PN_RR__ (size, imm2, PNn, Pd) = {
       },
       2048 => {
           execute_PEXT_PN_RR__(2048, d, esize, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56497,8 +55687,7 @@ function decode_PEXT_PP_RR__ (size, i1, PNn, Pd) = {
       },
       2048 => {
           execute_PEXT_PP_RR__(2048, d0, d1, esize, n, part)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56552,8 +55741,7 @@ function decode_PTRUE_PN_I__ (size, PNd) = {
       },
       2048 => {
           execute_PTRUE_PN_I__(2048, d, esize)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56621,8 +55809,7 @@ function decode_CNTP_R_PN__ (size, vl, PNn, Rd) = {
       2048 => {
           assert(constraint(('width in {2, 4} & 0 <= 'n & 'n <= 15 & 'esize in {8, 16, 32, 64} & 0 <= 'd & 'd <= 31 & is_VL(2048))));
           execute_CNTP_R_PN__(2048, d, esize, n, width)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56661,7 +55848,7 @@ function execute_WHILELO_PN_RR__ (VL, d, esize, invert, m, n, op, rsize, is_unsi
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELO_PN_RR__")
         };
         last = last & cond;
         if last then {
@@ -56711,8 +55898,7 @@ function decode_WHILELO_PN_RR__ (size, Rm, vl, U, lt, Rn, eq, PNd) = {
       2048 => {
           assert(constraint(('width in {2, 4} & 0 <= 'n & 'n <= 31 & 0 <= 'm & 'm <= 31 & 'esize in {8, 16, 32, 64} & 0 <= 'd & 'd <= 15 & is_VL(2048))));
           execute_WHILELO_PN_RR__(2048, d, esize, invert, m, n, op, rsize, is_unsigned, width)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56755,7 +55941,7 @@ function execute_WHILELS_PN_RR__ (VL, d, esize, invert, m, n, op, rsize, is_unsi
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELS_PN_RR__")
         };
         last = last & cond;
         if last then {
@@ -56805,8 +55991,7 @@ function decode_WHILELS_PN_RR__ (size, Rm, vl, U, lt, Rn, eq, PNd) = {
       2048 => {
           assert(constraint(('width in {2, 4} & 0 <= 'n & 'n <= 31 & 0 <= 'm & 'm <= 31 & 'esize in {8, 16, 32, 64} & 0 <= 'd & 'd <= 15 & is_VL(2048))));
           execute_WHILELS_PN_RR__(2048, d, esize, invert, m, n, op, rsize, is_unsigned, width)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56849,7 +56034,7 @@ function execute_WHILELT_PN_RR__ (VL, d, esize, invert, m, n, op, rsize, is_unsi
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELT_PN_RR__")
         };
         last = last & cond;
         if last then {
@@ -56899,8 +56084,7 @@ function decode_WHILELT_PN_RR__ (size, Rm, vl, U, lt, Rn, eq, PNd) = {
       2048 => {
           assert(constraint(('width in {2, 4} & 0 <= 'n & 'n <= 31 & 0 <= 'm & 'm <= 31 & 'esize in {8, 16, 32, 64} & 0 <= 'd & 'd <= 15 & is_VL(2048))));
           execute_WHILELT_PN_RR__(2048, d, esize, invert, m, n, op, rsize, is_unsigned, width)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -56943,7 +56127,7 @@ function execute_WHILELE_PN_RR__ (VL, d, esize, invert, m, n, op, rsize, is_unsi
           Cmp_LE => {
               cond = asl_Int(operand1, is_unsigned) <= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILELE_PN_RR__")
         };
         last = last & cond;
         if last then {
@@ -56993,8 +56177,7 @@ function decode_WHILELE_PN_RR__ (size, Rm, vl, U, lt, Rn, eq, PNd) = {
       2048 => {
           assert(constraint(('width in {2, 4} & 0 <= 'n & 'n <= 31 & 0 <= 'm & 'm <= 31 & 'esize in {8, 16, 32, 64} & 0 <= 'd & 'd <= 15 & is_VL(2048))));
           execute_WHILELE_PN_RR__(2048, d, esize, invert, m, n, op, rsize, is_unsigned, width)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57037,7 +56220,7 @@ function execute_WHILEHI_PN_RR__ (VL, d, esize, invert, m, n, op, rsize, is_unsi
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEHI_PN_RR__")
         };
         last = last & cond;
         if last then {
@@ -57087,8 +56270,7 @@ function decode_WHILEHI_PN_RR__ (size, Rm, vl, U, lt, Rn, eq, PNd) = {
       2048 => {
           assert(constraint(('width in {2, 4} & 0 <= 'n & 'n <= 31 & 0 <= 'm & 'm <= 31 & 'esize in {8, 16, 32, 64} & 0 <= 'd & 'd <= 15 & is_VL(2048))));
           execute_WHILEHI_PN_RR__(2048, d, esize, invert, m, n, op, rsize, is_unsigned, width)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57131,7 +56313,7 @@ function execute_WHILEHS_PN_RR__ (VL, d, esize, invert, m, n, op, rsize, is_unsi
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEHS_PN_RR__")
         };
         last = last & cond;
         if last then {
@@ -57181,8 +56363,7 @@ function decode_WHILEHS_PN_RR__ (size, Rm, vl, U, lt, Rn, eq, PNd) = {
       2048 => {
           assert(constraint(('width in {2, 4} & 0 <= 'n & 'n <= 31 & 0 <= 'm & 'm <= 31 & 'esize in {8, 16, 32, 64} & 0 <= 'd & 'd <= 15 & is_VL(2048))));
           execute_WHILEHS_PN_RR__(2048, d, esize, invert, m, n, op, rsize, is_unsigned, width)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57225,7 +56406,7 @@ function execute_WHILEGT_PN_RR__ (VL, d, esize, invert, m, n, op, rsize, is_unsi
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEGT_PN_RR__")
         };
         last = last & cond;
         if last then {
@@ -57275,8 +56456,7 @@ function decode_WHILEGT_PN_RR__ (size, Rm, vl, U, lt, Rn, eq, PNd) = {
       2048 => {
           assert(constraint(('width in {2, 4} & 0 <= 'n & 'n <= 31 & 0 <= 'm & 'm <= 31 & 'esize in {8, 16, 32, 64} & 0 <= 'd & 'd <= 15 & is_VL(2048))));
           execute_WHILEGT_PN_RR__(2048, d, esize, invert, m, n, op, rsize, is_unsigned, width)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57319,7 +56499,7 @@ function execute_WHILEGE_PN_RR__ (VL, d, esize, invert, m, n, op, rsize, is_unsi
           Cmp_GE => {
               cond = asl_Int(operand1, is_unsigned) >= asl_Int(operand2, is_unsigned)
           },
-          _ => ()
+          _ => PatternMatchFailure("execute_WHILEGE_PN_RR__")
         };
         last = last & cond;
         if last then {
@@ -57369,8 +56549,7 @@ function decode_WHILEGE_PN_RR__ (size, Rm, vl, U, lt, Rn, eq, PNd) = {
       2048 => {
           assert(constraint(('width in {2, 4} & 0 <= 'n & 'n <= 31 & 0 <= 'm & 'm <= 31 & 'esize in {8, 16, 32, 64} & 0 <= 'd & 'd <= 15 & is_VL(2048))));
           execute_WHILEGE_PN_RR__(2048, d, esize, invert, m, n, op, rsize, is_unsigned, width)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57463,8 +56642,7 @@ function decode_LD1B_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57556,8 +56734,7 @@ function decode_LD1SB_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57673,8 +56850,7 @@ function decode_LDFF1B_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1B_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57790,8 +56966,7 @@ function decode_LDFF1SB_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SB_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57883,8 +57058,7 @@ function decode_LD1H_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -57976,8 +57150,7 @@ function decode_LD1SH_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58093,8 +57266,7 @@ function decode_LDFF1H_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58210,8 +57382,7 @@ function decode_LDFF1SH_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SH_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58303,8 +57474,7 @@ function decode_LD1W_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58420,8 +57590,7 @@ function decode_LDFF1W_Z_P_BZ_S_x32_unscaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1W_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58498,8 +57667,7 @@ function decode_PRFB_I_P_BZ_S_x32_scaled (xs, Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFB_I_P_BZ_S_x32_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58575,8 +57743,7 @@ function decode_PRFH_I_P_BZ_S_x32_scaled (xs, Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFH_I_P_BZ_S_x32_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58652,8 +57819,7 @@ function decode_PRFW_I_P_BZ_S_x32_scaled (xs, Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFW_I_P_BZ_S_x32_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58729,8 +57895,7 @@ function decode_PRFD_I_P_BZ_S_x32_scaled (xs, Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFD_I_P_BZ_S_x32_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58821,8 +57986,7 @@ function decode_LD1H_Z_P_BZ_S_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BZ_S_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -58914,8 +58078,7 @@ function decode_LD1SH_Z_P_BZ_S_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BZ_S_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59031,8 +58194,7 @@ function decode_LDFF1H_Z_P_BZ_S_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_BZ_S_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59148,8 +58310,7 @@ function decode_LDFF1SH_Z_P_BZ_S_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SH_Z_P_BZ_S_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59241,8 +58402,7 @@ function decode_LD1W_Z_P_BZ_S_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BZ_S_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59358,8 +58518,7 @@ function decode_LDFF1W_Z_P_BZ_S_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1W_Z_P_BZ_S_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59436,8 +58595,7 @@ function decode_LDR_P_BI__ (imm9h, imm9l, Rn, Pt) = {
       },
       2048 => {
           execute_LDR_P_BI__(2048, imm, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59511,8 +58669,7 @@ function decode_LDR_Z_BI__ (imm9h, imm9l, Rn, Zt) = {
       },
       2048 => {
           execute_LDR_Z_BI__(2048, imm, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59581,8 +58738,7 @@ function decode_PRFB_I_P_BI_S (imm6, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFB_I_P_BI_S(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59652,8 +58808,7 @@ function decode_PRFH_I_P_BI_S (imm6, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFH_I_P_BI_S(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59723,8 +58878,7 @@ function decode_PRFW_I_P_BI_S (imm6, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFW_I_P_BI_S(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59794,8 +58948,7 @@ function decode_PRFD_I_P_BI_S (imm6, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFD_I_P_BI_S(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59871,8 +59024,7 @@ function decode_PRFB_I_P_BR_S (msz, Rm, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFB_I_P_BR_S(2048, esize, g, level, m, n, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -59948,8 +59100,7 @@ function decode_PRFH_I_P_BR_S (msz, Rm, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFH_I_P_BR_S(2048, esize, g, level, m, n, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60025,8 +59176,7 @@ function decode_PRFW_I_P_BR_S (msz, Rm, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFW_I_P_BR_S(2048, esize, g, level, m, n, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60102,8 +59252,7 @@ function decode_PRFD_I_P_BR_S (msz, Rm, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFD_I_P_BR_S(2048, esize, g, level, m, n, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60172,8 +59321,7 @@ function decode_PRFB_I_P_AI_S (msz, imm5, Pg, Zn, prfop) = {
       },
       2048 => {
           execute_PRFB_I_P_AI_S(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60242,8 +59390,7 @@ function decode_PRFH_I_P_AI_S (msz, imm5, Pg, Zn, prfop) = {
       },
       2048 => {
           execute_PRFH_I_P_AI_S(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60312,8 +59459,7 @@ function decode_PRFW_I_P_AI_S (msz, imm5, Pg, Zn, prfop) = {
       },
       2048 => {
           execute_PRFW_I_P_AI_S(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60382,8 +59528,7 @@ function decode_PRFD_I_P_AI_S (msz, imm5, Pg, Zn, prfop) = {
       },
       2048 => {
           execute_PRFD_I_P_AI_S(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60460,8 +59605,7 @@ function decode_LD1B_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60540,8 +59684,7 @@ function decode_LD1SB_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60644,8 +59787,7 @@ function decode_LDFF1B_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1B_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60748,8 +59890,7 @@ function decode_LDFF1SB_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1SB_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60828,8 +59969,7 @@ function decode_LD1H_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -60908,8 +60048,7 @@ function decode_LD1SH_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61012,8 +60151,7 @@ function decode_LDFF1H_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61116,8 +60254,7 @@ function decode_LDFF1SH_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1SH_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61196,8 +60333,7 @@ function decode_LD1W_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61300,8 +60436,7 @@ function decode_LDFF1W_Z_P_AI_S (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1W_Z_P_AI_S(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61387,8 +60522,7 @@ function decode_LD1RB_Z_P_BI_U8 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RB_Z_P_BI_U8(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61473,8 +60607,7 @@ function decode_LD1RB_Z_P_BI_U16 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RB_Z_P_BI_U16(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61559,8 +60692,7 @@ function decode_LD1RB_Z_P_BI_U32 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RB_Z_P_BI_U32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61645,8 +60777,7 @@ function decode_LD1RB_Z_P_BI_U64 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RB_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61731,8 +60862,7 @@ function decode_LD1RSW_Z_P_BI_S64 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RSW_Z_P_BI_S64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61817,8 +60947,7 @@ function decode_LD1RH_Z_P_BI_U16 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RH_Z_P_BI_U16(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61903,8 +61032,7 @@ function decode_LD1RH_Z_P_BI_U32 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RH_Z_P_BI_U32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -61989,8 +61117,7 @@ function decode_LD1RH_Z_P_BI_U64 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RH_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62075,8 +61202,7 @@ function decode_LD1RSH_Z_P_BI_S64 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RSH_Z_P_BI_S64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62161,8 +61287,7 @@ function decode_LD1RSH_Z_P_BI_S32 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RSH_Z_P_BI_S32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62247,8 +61372,7 @@ function decode_LD1RW_Z_P_BI_U32 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RW_Z_P_BI_U32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62333,8 +61457,7 @@ function decode_LD1RW_Z_P_BI_U64 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RW_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62419,8 +61542,7 @@ function decode_LD1RSB_Z_P_BI_S64 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RSB_Z_P_BI_S64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62505,8 +61627,7 @@ function decode_LD1RSB_Z_P_BI_S32 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RSB_Z_P_BI_S32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62591,8 +61712,7 @@ function decode_LD1RSB_Z_P_BI_S16 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RSB_Z_P_BI_S16(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62677,8 +61797,7 @@ function decode_LD1RD_Z_P_BI_U64 (dtypeh, imm6, dtypel, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RD_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62768,8 +61887,7 @@ function decode_LD1B_Z_P_BR_U8 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BR_U8(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62858,8 +61976,7 @@ function decode_LD1B_Z_P_BR_U16 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BR_U16(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -62948,8 +62065,7 @@ function decode_LD1B_Z_P_BR_U32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BR_U32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63038,8 +62154,7 @@ function decode_LD1B_Z_P_BR_U64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BR_U64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63128,8 +62243,7 @@ function decode_LD1SW_Z_P_BR_S64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SW_Z_P_BR_S64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63218,8 +62332,7 @@ function decode_LD1H_Z_P_BR_U16 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BR_U16(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63308,8 +62421,7 @@ function decode_LD1H_Z_P_BR_U32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BR_U32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63398,8 +62510,7 @@ function decode_LD1H_Z_P_BR_U64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BR_U64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63488,8 +62599,7 @@ function decode_LD1SH_Z_P_BR_S64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BR_S64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63578,8 +62688,7 @@ function decode_LD1SH_Z_P_BR_S32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BR_S32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63672,8 +62781,7 @@ function decode_LD1W_Z_P_BR_U32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BR_U32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63766,8 +62874,7 @@ function decode_LD1W_Z_P_BR_U64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BR_U64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63856,8 +62963,7 @@ function decode_LD1SB_Z_P_BR_S64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_BR_S64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -63946,8 +63052,7 @@ function decode_LD1SB_Z_P_BR_S32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_BR_S32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64036,8 +63141,7 @@ function decode_LD1SB_Z_P_BR_S16 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_BR_S16(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64130,8 +63234,7 @@ function decode_LD1D_Z_P_BR_U64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1D_Z_P_BR_U64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64224,8 +63327,7 @@ function decode_LD1W_Z_P_BR_U128 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BR_U128(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64318,8 +63420,7 @@ function decode_LD1D_Z_P_BR_U128 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1D_Z_P_BR_U128(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64429,8 +63530,7 @@ function decode_LDFF1B_Z_P_BR_U8 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1B_Z_P_BR_U8(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64540,8 +63640,7 @@ function decode_LDFF1B_Z_P_BR_U16 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1B_Z_P_BR_U16(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64651,8 +63750,7 @@ function decode_LDFF1B_Z_P_BR_U32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1B_Z_P_BR_U32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64762,8 +63860,7 @@ function decode_LDFF1B_Z_P_BR_U64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1B_Z_P_BR_U64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64873,8 +63970,7 @@ function decode_LDFF1SW_Z_P_BR_S64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SW_Z_P_BR_S64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -64984,8 +64080,7 @@ function decode_LDFF1H_Z_P_BR_U16 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_BR_U16(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -65095,8 +64190,7 @@ function decode_LDFF1H_Z_P_BR_U32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_BR_U32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -65206,8 +64300,7 @@ function decode_LDFF1H_Z_P_BR_U64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_BR_U64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -65317,8 +64410,7 @@ function decode_LDFF1SH_Z_P_BR_S64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SH_Z_P_BR_S64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -65428,8 +64520,7 @@ function decode_LDFF1SH_Z_P_BR_S32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SH_Z_P_BR_S32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -65539,8 +64630,7 @@ function decode_LDFF1W_Z_P_BR_U32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1W_Z_P_BR_U32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -65650,8 +64740,7 @@ function decode_LDFF1W_Z_P_BR_U64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1W_Z_P_BR_U64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -65761,8 +64850,7 @@ function decode_LDFF1SB_Z_P_BR_S64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SB_Z_P_BR_S64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -65872,8 +64960,7 @@ function decode_LDFF1SB_Z_P_BR_S32 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SB_Z_P_BR_S32(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -65983,8 +65070,7 @@ function decode_LDFF1SB_Z_P_BR_S16 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SB_Z_P_BR_S16(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66094,8 +65180,7 @@ function decode_LDFF1D_Z_P_BR_U64 (dtype, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1D_Z_P_BR_U64(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66180,8 +65265,7 @@ function decode_LDNT1B_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNT1B_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66266,8 +65350,7 @@ function decode_LDNT1H_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNT1H_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66352,8 +65435,7 @@ function decode_LDNT1W_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNT1W_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66438,8 +65520,7 @@ function decode_LDNT1D_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNT1D_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66530,8 +65611,7 @@ function decode_LD2B_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2B_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66622,8 +65702,7 @@ function decode_LD2H_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2H_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66714,8 +65793,7 @@ function decode_LD2W_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2W_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66806,8 +65884,7 @@ function decode_LD2D_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2D_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66898,8 +65975,7 @@ function decode_LD3B_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3B_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -66990,8 +66066,7 @@ function decode_LD3H_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3H_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67082,8 +66157,7 @@ function decode_LD3W_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3W_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67174,8 +66248,7 @@ function decode_LD3D_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3D_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67266,8 +66339,7 @@ function decode_LD4B_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4B_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67358,8 +66430,7 @@ function decode_LD4H_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4H_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67450,8 +66521,7 @@ function decode_LD4W_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4W_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67542,8 +66612,7 @@ function decode_LD4D_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4D_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67634,8 +66703,7 @@ function decode_LD2Q_Z_P_BR_Contiguous (num, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2Q_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67726,8 +66794,7 @@ function decode_LD3Q_Z_P_BR_Contiguous (num, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3Q_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67818,8 +66885,7 @@ function decode_LD4Q_Z_P_BR_Contiguous (num, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4Q_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67905,8 +66971,7 @@ function decode_LD1RQB_Z_P_BR_Contiguous (msz, ssz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RQB_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -67993,8 +67058,7 @@ function decode_LD1RQH_Z_P_BR_Contiguous (msz, ssz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RQH_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68081,8 +67145,7 @@ function decode_LD1RQW_Z_P_BR_Contiguous (msz, ssz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RQW_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68169,8 +67232,7 @@ function decode_LD1RQD_Z_P_BR_Contiguous (msz, ssz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RQD_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68260,8 +67322,7 @@ function decode_LD1ROB_Z_P_BR_Contiguous (msz, ssz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1ROB_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68351,8 +67412,7 @@ function decode_LD1ROH_Z_P_BR_Contiguous (msz, ssz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1ROH_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68442,8 +67502,7 @@ function decode_LD1ROW_Z_P_BR_Contiguous (msz, ssz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1ROW_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68533,8 +67592,7 @@ function decode_LD1ROD_Z_P_BR_Contiguous (msz, ssz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1ROD_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68620,8 +67678,7 @@ function decode_LD1B_Z_P_BI_U8 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BI_U8(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68706,8 +67763,7 @@ function decode_LD1B_Z_P_BI_U16 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BI_U16(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68792,8 +67848,7 @@ function decode_LD1B_Z_P_BI_U32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BI_U32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68878,8 +67933,7 @@ function decode_LD1B_Z_P_BI_U64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -68964,8 +68018,7 @@ function decode_LD1SW_Z_P_BI_S64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SW_Z_P_BI_S64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69050,8 +68103,7 @@ function decode_LD1H_Z_P_BI_U16 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BI_U16(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69136,8 +68188,7 @@ function decode_LD1H_Z_P_BI_U32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BI_U32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69222,8 +68273,7 @@ function decode_LD1H_Z_P_BI_U64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69308,8 +68358,7 @@ function decode_LD1SH_Z_P_BI_S64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BI_S64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69394,8 +68443,7 @@ function decode_LD1SH_Z_P_BI_S32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BI_S32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69484,8 +68532,7 @@ function decode_LD1W_Z_P_BI_U32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BI_U32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69574,8 +68621,7 @@ function decode_LD1W_Z_P_BI_U64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69660,8 +68706,7 @@ function decode_LD1SB_Z_P_BI_S64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_BI_S64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69746,8 +68791,7 @@ function decode_LD1SB_Z_P_BI_S32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_BI_S32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69832,8 +68876,7 @@ function decode_LD1SB_Z_P_BI_S16 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_BI_S16(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -69922,8 +68965,7 @@ function decode_LD1D_Z_P_BI_U64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1D_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70026,8 +69068,7 @@ function decode_LDNF1B_Z_P_BI_U8 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1B_Z_P_BI_U8(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70130,8 +69171,7 @@ function decode_LDNF1B_Z_P_BI_U16 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1B_Z_P_BI_U16(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70234,8 +69274,7 @@ function decode_LDNF1B_Z_P_BI_U32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1B_Z_P_BI_U32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70338,8 +69377,7 @@ function decode_LDNF1B_Z_P_BI_U64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1B_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70442,8 +69480,7 @@ function decode_LDNF1SW_Z_P_BI_S64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1SW_Z_P_BI_S64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70546,8 +69583,7 @@ function decode_LDNF1H_Z_P_BI_U16 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1H_Z_P_BI_U16(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70650,8 +69686,7 @@ function decode_LDNF1H_Z_P_BI_U32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1H_Z_P_BI_U32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70754,8 +69789,7 @@ function decode_LDNF1H_Z_P_BI_U64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1H_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70858,8 +69892,7 @@ function decode_LDNF1SH_Z_P_BI_S64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1SH_Z_P_BI_S64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -70962,8 +69995,7 @@ function decode_LDNF1SH_Z_P_BI_S32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1SH_Z_P_BI_S32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71066,8 +70098,7 @@ function decode_LDNF1W_Z_P_BI_U32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1W_Z_P_BI_U32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71170,8 +70201,7 @@ function decode_LDNF1W_Z_P_BI_U64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1W_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71274,8 +70304,7 @@ function decode_LDNF1SB_Z_P_BI_S64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1SB_Z_P_BI_S64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71378,8 +70407,7 @@ function decode_LDNF1SB_Z_P_BI_S32 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1SB_Z_P_BI_S32(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71482,8 +70510,7 @@ function decode_LDNF1SB_Z_P_BI_S16 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1SB_Z_P_BI_S16(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71586,8 +70613,7 @@ function decode_LDNF1D_Z_P_BI_U64 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNF1D_Z_P_BI_U64(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71676,8 +70702,7 @@ function decode_LD1W_Z_P_BI_U128 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BI_U128(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71766,8 +70791,7 @@ function decode_LD1D_Z_P_BI_U128 (dtype, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1D_Z_P_BI_U128(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71848,8 +70872,7 @@ function decode_LDNT1B_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNT1B_Z_P_BI_Contiguous(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -71930,8 +70953,7 @@ function decode_LDNT1H_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNT1H_Z_P_BI_Contiguous(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72012,8 +71034,7 @@ function decode_LDNT1W_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNT1W_Z_P_BI_Contiguous(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72094,8 +71115,7 @@ function decode_LDNT1D_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDNT1D_Z_P_BI_Contiguous(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72181,8 +71201,7 @@ function decode_LD2B_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2B_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72268,8 +71287,7 @@ function decode_LD2H_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2H_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72355,8 +71373,7 @@ function decode_LD2W_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2W_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72442,8 +71459,7 @@ function decode_LD2D_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2D_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72529,8 +71545,7 @@ function decode_LD3B_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3B_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72616,8 +71631,7 @@ function decode_LD3H_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3H_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72703,8 +71717,7 @@ function decode_LD3W_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3W_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72790,8 +71803,7 @@ function decode_LD3D_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3D_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72877,8 +71889,7 @@ function decode_LD4B_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4B_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -72964,8 +71975,7 @@ function decode_LD4H_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4H_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73051,8 +72061,7 @@ function decode_LD4W_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4W_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73138,8 +72147,7 @@ function decode_LD4D_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4D_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73225,8 +72233,7 @@ function decode_LD2Q_Z_P_BI_Contiguous (num, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD2Q_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73312,8 +72319,7 @@ function decode_LD3Q_Z_P_BI_Contiguous (num, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD3Q_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73399,8 +72405,7 @@ function decode_LD4Q_Z_P_BI_Contiguous (num, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD4Q_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73480,8 +72485,7 @@ function decode_LD1RQB_Z_P_BI_U8 (msz, ssz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RQB_Z_P_BI_U8(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73562,8 +72566,7 @@ function decode_LD1RQH_Z_P_BI_U16 (msz, ssz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RQH_Z_P_BI_U16(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73644,8 +72647,7 @@ function decode_LD1RQW_Z_P_BI_U32 (msz, ssz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RQW_Z_P_BI_U32(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73726,8 +72728,7 @@ function decode_LD1RQD_Z_P_BI_U64 (msz, ssz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1RQD_Z_P_BI_U64(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73812,8 +72813,7 @@ function decode_LD1ROB_Z_P_BI_U8 (msz, ssz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1ROB_Z_P_BI_U8(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73898,8 +72898,7 @@ function decode_LD1ROH_Z_P_BI_U16 (msz, ssz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1ROH_Z_P_BI_U16(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -73984,8 +72983,7 @@ function decode_LD1ROW_Z_P_BI_U32 (msz, ssz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1ROW_Z_P_BI_U32(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -74070,8 +73068,7 @@ function decode_LD1ROD_Z_P_BI_U64 (msz, ssz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1ROD_Z_P_BI_U64(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -74162,8 +73159,7 @@ function decode_LD1B_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -74256,8 +73252,7 @@ function decode_LD1SB_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -74374,8 +73369,7 @@ function decode_LDFF1B_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = 
       },
       2048 => {
           execute_LDFF1B_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -74492,8 +73486,7 @@ function decode_LDFF1SB_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) =
       },
       2048 => {
           execute_LDFF1SB_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -74586,8 +73579,7 @@ function decode_LD1H_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -74680,8 +73672,7 @@ function decode_LD1SH_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -74798,8 +73789,7 @@ function decode_LDFF1H_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = 
       },
       2048 => {
           execute_LDFF1H_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -74916,8 +73906,7 @@ function decode_LDFF1SH_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) =
       },
       2048 => {
           execute_LDFF1SH_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75010,8 +73999,7 @@ function decode_LD1W_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75104,8 +74092,7 @@ function decode_LD1SW_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SW_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75222,8 +74209,7 @@ function decode_LDFF1W_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = 
       },
       2048 => {
           execute_LDFF1W_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75340,8 +74326,7 @@ function decode_LDFF1SW_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) =
       },
       2048 => {
           execute_LDFF1SW_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75434,8 +74419,7 @@ function decode_LD1D_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1D_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75552,8 +74536,7 @@ function decode_LDFF1D_Z_P_BZ_D_x32_unscaled (msz, xs, Zm, U, ff, Pg, Rn, Zt) = 
       },
       2048 => {
           execute_LDFF1D_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75631,8 +74614,7 @@ function decode_PRFB_I_P_BZ_D_x32_scaled (xs, Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFB_I_P_BZ_D_x32_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75708,8 +74690,7 @@ function decode_PRFH_I_P_BZ_D_x32_scaled (xs, Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFH_I_P_BZ_D_x32_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75785,8 +74766,7 @@ function decode_PRFW_I_P_BZ_D_x32_scaled (xs, Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFW_I_P_BZ_D_x32_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75862,8 +74842,7 @@ function decode_PRFD_I_P_BZ_D_x32_scaled (xs, Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFD_I_P_BZ_D_x32_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -75954,8 +74933,7 @@ function decode_LD1H_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76047,8 +75025,7 @@ function decode_LD1SH_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76164,8 +75141,7 @@ function decode_LDFF1H_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76281,8 +75257,7 @@ function decode_LDFF1SH_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SH_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76374,8 +75349,7 @@ function decode_LD1W_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76467,8 +75441,7 @@ function decode_LD1SW_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SW_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76584,8 +75557,7 @@ function decode_LDFF1W_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1W_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76701,8 +75673,7 @@ function decode_LDFF1SW_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SW_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76794,8 +75765,7 @@ function decode_LD1D_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1D_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76911,8 +75881,7 @@ function decode_LDFF1D_Z_P_BZ_D_x32_scaled (xs, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1D_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -76983,8 +75952,7 @@ function decode_PRFB_I_P_AI_D (msz, imm5, Pg, Zn, prfop) = {
       },
       2048 => {
           execute_PRFB_I_P_AI_D(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77053,8 +76021,7 @@ function decode_PRFH_I_P_AI_D (msz, imm5, Pg, Zn, prfop) = {
       },
       2048 => {
           execute_PRFH_I_P_AI_D(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77123,8 +76090,7 @@ function decode_PRFW_I_P_AI_D (msz, imm5, Pg, Zn, prfop) = {
       },
       2048 => {
           execute_PRFW_I_P_AI_D(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77193,8 +76159,7 @@ function decode_PRFD_I_P_AI_D (msz, imm5, Pg, Zn, prfop) = {
       },
       2048 => {
           execute_PRFD_I_P_AI_D(2048, esize, g, level, n, offset, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77271,8 +76236,7 @@ function decode_LD1B_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77351,8 +76315,7 @@ function decode_LD1SB_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77455,8 +76418,7 @@ function decode_LDFF1B_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1B_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77559,8 +76521,7 @@ function decode_LDFF1SB_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1SB_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77639,8 +76600,7 @@ function decode_LD1H_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77719,8 +76679,7 @@ function decode_LD1SH_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77823,8 +76782,7 @@ function decode_LDFF1H_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -77927,8 +76885,7 @@ function decode_LDFF1SH_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1SH_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78007,8 +76964,7 @@ function decode_LD1W_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78087,8 +77043,7 @@ function decode_LD1SW_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1SW_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78191,8 +77146,7 @@ function decode_LDFF1W_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1W_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78295,8 +77249,7 @@ function decode_LDFF1SW_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1SW_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78375,8 +77328,7 @@ function decode_LD1D_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1D_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78479,8 +77431,7 @@ function decode_LDFF1D_Z_P_AI_D (msz, imm5, U, ff, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDFF1D_Z_P_AI_D(2048, esize, g, msize, n, offset, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78572,8 +77523,7 @@ function decode_LD1B_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1B_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78665,8 +77615,7 @@ function decode_LD1SB_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SB_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78782,8 +77731,7 @@ function decode_LDFF1B_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1B_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78899,8 +77847,7 @@ function decode_LDFF1SB_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SB_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -78992,8 +77939,7 @@ function decode_LD1H_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -79085,8 +78031,7 @@ function decode_LD1SH_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -79202,8 +78147,7 @@ function decode_LDFF1H_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -79319,8 +78263,7 @@ function decode_LDFF1SH_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SH_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -79412,8 +78355,7 @@ function decode_LD1W_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -79505,8 +78447,7 @@ function decode_LD1SW_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SW_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -79622,8 +78563,7 @@ function decode_LDFF1W_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1W_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -79739,8 +78679,7 @@ function decode_LDFF1SW_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SW_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -79832,8 +78771,7 @@ function decode_LD1D_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1D_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -79949,8 +78887,7 @@ function decode_LDFF1D_Z_P_BZ_D_64_unscaled (msz, Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1D_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80027,8 +78964,7 @@ function decode_PRFB_I_P_BZ_D_64_scaled (Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFB_I_P_BZ_D_64_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80103,8 +79039,7 @@ function decode_PRFH_I_P_BZ_D_64_scaled (Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFH_I_P_BZ_D_64_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80179,8 +79114,7 @@ function decode_PRFW_I_P_BZ_D_64_scaled (Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFW_I_P_BZ_D_64_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80255,8 +79189,7 @@ function decode_PRFD_I_P_BZ_D_64_scaled (Zm, msz, Pg, Rn, prfop) = {
       },
       2048 => {
           execute_PRFD_I_P_BZ_D_64_scaled(2048, esize, g, level, m, n, offs_size, offs_unsigned, pref_hint, scale, stream)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80346,8 +79279,7 @@ function decode_LD1H_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1H_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80438,8 +79370,7 @@ function decode_LD1SH_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SH_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80554,8 +79485,7 @@ function decode_LDFF1H_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1H_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80670,8 +79600,7 @@ function decode_LDFF1SH_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SH_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80762,8 +79691,7 @@ function decode_LD1W_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1W_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80854,8 +79782,7 @@ function decode_LD1SW_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1SW_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -80970,8 +79897,7 @@ function decode_LDFF1W_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1W_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81086,8 +80012,7 @@ function decode_LDFF1SW_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1SW_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81178,8 +80103,7 @@ function decode_LD1D_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LD1D_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81294,8 +80218,7 @@ function decode_LDFF1D_Z_P_BZ_D_64_scaled (Zm, U, ff, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_LDFF1D_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81381,8 +80304,7 @@ function decode_ST1B_Z_P_BR__ (size, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1B_Z_P_BR__(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81471,8 +80393,7 @@ function decode_ST1H_Z_P_BR__ (size, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_BR__(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81561,8 +80482,7 @@ function decode_ST1W_Z_P_BR__ (sz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BR__(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81651,8 +80571,7 @@ function decode_ST1D_Z_P_BR__ (Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1D_Z_P_BR__(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81740,8 +80659,7 @@ function decode_ST1W_Z_P_BR_U128 (Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BR_U128(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81829,8 +80747,7 @@ function decode_ST1D_Z_P_BR_U128 (Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1D_Z_P_BR_U128(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81902,8 +80819,7 @@ function decode_STR_P_BI__ (imm9h, imm9l, Rn, Pt) = {
       },
       2048 => {
           execute_STR_P_BI__(2048, imm, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -81975,8 +80891,7 @@ function decode_STR_Z_BI__ (imm9h, imm9l, Rn, Zt) = {
       },
       2048 => {
           execute_STR_Z_BI__(2048, imm, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82059,8 +80974,7 @@ function decode_STNT1B_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_STNT1B_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82144,8 +81058,7 @@ function decode_STNT1H_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_STNT1H_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82229,8 +81142,7 @@ function decode_STNT1W_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_STNT1W_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82314,8 +81226,7 @@ function decode_STNT1D_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_STNT1D_Z_P_BR_Contiguous(2048, esize, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82405,8 +81316,7 @@ function decode_ST2B_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2B_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82496,8 +81406,7 @@ function decode_ST2H_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2H_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82587,8 +81496,7 @@ function decode_ST2W_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2W_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82678,8 +81586,7 @@ function decode_ST2D_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2D_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82769,8 +81676,7 @@ function decode_ST3B_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3B_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82860,8 +81766,7 @@ function decode_ST3H_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3H_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -82951,8 +81856,7 @@ function decode_ST3W_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3W_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83042,8 +81946,7 @@ function decode_ST3D_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3D_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83133,8 +82036,7 @@ function decode_ST4B_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4B_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83224,8 +82126,7 @@ function decode_ST4H_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4H_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83315,8 +82216,7 @@ function decode_ST4W_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4W_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83406,8 +82306,7 @@ function decode_ST4D_Z_P_BR_Contiguous (msz, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4D_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83497,8 +82396,7 @@ function decode_ST2Q_Z_P_BR_Contiguous (num, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2Q_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83588,8 +82486,7 @@ function decode_ST3Q_Z_P_BR_Contiguous (num, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3Q_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83679,8 +82576,7 @@ function decode_ST4Q_Z_P_BR_Contiguous (num, Rm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4Q_Z_P_BR_Contiguous(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83766,8 +82662,7 @@ function decode_ST1B_Z_P_BZ_D_x32_unscaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1B_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83854,8 +82749,7 @@ function decode_ST1H_Z_P_BZ_D_x32_unscaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -83942,8 +82836,7 @@ function decode_ST1W_Z_P_BZ_D_x32_unscaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84030,8 +82923,7 @@ function decode_ST1D_Z_P_BZ_D_x32_unscaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1D_Z_P_BZ_D_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84118,8 +83010,7 @@ function decode_ST1B_Z_P_BZ_S_x32_unscaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1B_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84206,8 +83097,7 @@ function decode_ST1H_Z_P_BZ_S_x32_unscaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84294,8 +83184,7 @@ function decode_ST1W_Z_P_BZ_S_x32_unscaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BZ_S_x32_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84382,8 +83271,7 @@ function decode_ST1H_Z_P_BZ_D_x32_scaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84470,8 +83358,7 @@ function decode_ST1W_Z_P_BZ_D_x32_scaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84558,8 +83445,7 @@ function decode_ST1D_Z_P_BZ_D_x32_scaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1D_Z_P_BZ_D_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84646,8 +83532,7 @@ function decode_ST1H_Z_P_BZ_S_x32_scaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_BZ_S_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84734,8 +83619,7 @@ function decode_ST1W_Z_P_BZ_S_x32_scaled (msz, Zm, xs, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BZ_S_x32_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84822,8 +83706,7 @@ function decode_ST1B_Z_P_BZ_D_64_unscaled (msz, Zm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1B_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84909,8 +83792,7 @@ function decode_ST1H_Z_P_BZ_D_64_unscaled (msz, Zm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -84996,8 +83878,7 @@ function decode_ST1W_Z_P_BZ_D_64_unscaled (msz, Zm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85083,8 +83964,7 @@ function decode_ST1D_Z_P_BZ_D_64_unscaled (msz, Zm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1D_Z_P_BZ_D_64_unscaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85170,8 +84050,7 @@ function decode_ST1H_Z_P_BZ_D_64_scaled (msz, Zm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85257,8 +84136,7 @@ function decode_ST1W_Z_P_BZ_D_64_scaled (msz, Zm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85344,8 +84222,7 @@ function decode_ST1D_Z_P_BZ_D_64_scaled (msz, Zm, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1D_Z_P_BZ_D_64_scaled(2048, esize, g, m, msize, n, offs_size, offs_unsigned, scale, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85419,8 +84296,7 @@ function decode_ST1B_Z_P_AI_D (msz, imm5, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_ST1B_Z_P_AI_D(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85494,8 +84370,7 @@ function decode_ST1H_Z_P_AI_D (msz, imm5, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_AI_D(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85569,8 +84444,7 @@ function decode_ST1W_Z_P_AI_D (msz, imm5, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_AI_D(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85644,8 +84518,7 @@ function decode_ST1D_Z_P_AI_D (msz, imm5, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_ST1D_Z_P_AI_D(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85719,8 +84592,7 @@ function decode_ST1B_Z_P_AI_S (msz, imm5, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_ST1B_Z_P_AI_S(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85794,8 +84666,7 @@ function decode_ST1H_Z_P_AI_S (msz, imm5, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_AI_S(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85869,8 +84740,7 @@ function decode_ST1W_Z_P_AI_S (msz, imm5, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_AI_S(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -85951,8 +84821,7 @@ function decode_ST1B_Z_P_BI__ (msz, size, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1B_Z_P_BI__(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86038,8 +84907,7 @@ function decode_ST1H_Z_P_BI__ (msz, size, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1H_Z_P_BI__(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86125,8 +84993,7 @@ function decode_ST1W_Z_P_BI__ (msz, sz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BI__(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86212,8 +85079,7 @@ function decode_ST1D_Z_P_BI__ (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1D_Z_P_BI__(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86298,8 +85164,7 @@ function decode_ST1W_Z_P_BI_U128 (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1W_Z_P_BI_U128(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86384,8 +85249,7 @@ function decode_ST1D_Z_P_BI_U128 (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST1D_Z_P_BI_U128(2048, esize, g, msize, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86465,8 +85329,7 @@ function decode_STNT1B_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_STNT1B_Z_P_BI_Contiguous(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86546,8 +85409,7 @@ function decode_STNT1H_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_STNT1H_Z_P_BI_Contiguous(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86627,8 +85489,7 @@ function decode_STNT1W_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_STNT1W_Z_P_BI_Contiguous(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86708,8 +85569,7 @@ function decode_STNT1D_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_STNT1D_Z_P_BI_Contiguous(2048, esize, g, n, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86794,8 +85654,7 @@ function decode_ST2B_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2B_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86880,8 +85739,7 @@ function decode_ST2H_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2H_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -86966,8 +85824,7 @@ function decode_ST2W_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2W_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87052,8 +85909,7 @@ function decode_ST2D_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2D_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87138,8 +85994,7 @@ function decode_ST3B_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3B_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87224,8 +86079,7 @@ function decode_ST3H_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3H_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87310,8 +86164,7 @@ function decode_ST3W_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3W_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87396,8 +86249,7 @@ function decode_ST3D_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3D_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87482,8 +86334,7 @@ function decode_ST4B_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4B_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87568,8 +86419,7 @@ function decode_ST4H_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4H_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87654,8 +86504,7 @@ function decode_ST4W_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4W_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87740,8 +86589,7 @@ function decode_ST4D_Z_P_BI_Contiguous (msz, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4D_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87826,8 +86674,7 @@ function decode_ST2Q_Z_P_BI_Contiguous (num, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST2Q_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87912,8 +86759,7 @@ function decode_ST3Q_Z_P_BI_Contiguous (num, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST3Q_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -87998,8 +86844,7 @@ function decode_ST4Q_Z_P_BI_Contiguous (num, imm4, Pg, Rn, Zt) = {
       },
       2048 => {
           execute_ST4Q_Z_P_BI_Contiguous(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88079,8 +86924,7 @@ function decode_LDNT1B_Z_P_AR_S_x32_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1B_Z_P_AR_S_x32_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88161,8 +87005,7 @@ function decode_LDNT1H_Z_P_AR_S_x32_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1H_Z_P_AR_S_x32_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88243,8 +87086,7 @@ function decode_LDNT1W_Z_P_AR_S_x32_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1W_Z_P_AR_S_x32_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88325,8 +87167,7 @@ function decode_LDNT1SB_Z_P_AR_S_x32_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1SB_Z_P_AR_S_x32_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88407,8 +87248,7 @@ function decode_LDNT1SH_Z_P_AR_S_x32_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1SH_Z_P_AR_S_x32_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88489,8 +87329,7 @@ function decode_LDNT1B_Z_P_AR_D_64_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1B_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88571,8 +87410,7 @@ function decode_LDNT1H_Z_P_AR_D_64_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1H_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88653,8 +87491,7 @@ function decode_LDNT1W_Z_P_AR_D_64_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1W_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88735,8 +87572,7 @@ function decode_LDNT1D_Z_P_AR_D_64_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1D_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88817,8 +87653,7 @@ function decode_LDNT1SB_Z_P_AR_D_64_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1SB_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88899,8 +87734,7 @@ function decode_LDNT1SH_Z_P_AR_D_64_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1SH_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -88981,8 +87815,7 @@ function decode_LDNT1SW_Z_P_AR_D_64_unscaled (msz, Rm, U, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LDNT1SW_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t, is_unsigned)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89060,8 +87893,7 @@ function decode_STNT1B_Z_P_AR_S_x32_unscaled (msz, Rm, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_STNT1B_Z_P_AR_S_x32_unscaled(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89138,8 +87970,7 @@ function decode_STNT1H_Z_P_AR_S_x32_unscaled (msz, Rm, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_STNT1H_Z_P_AR_S_x32_unscaled(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89216,8 +88047,7 @@ function decode_STNT1W_Z_P_AR_S_x32_unscaled (msz, Rm, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_STNT1W_Z_P_AR_S_x32_unscaled(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89294,8 +88124,7 @@ function decode_STNT1B_Z_P_AR_D_64_unscaled (msz, Rm, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_STNT1B_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89372,8 +88201,7 @@ function decode_STNT1H_Z_P_AR_D_64_unscaled (msz, Rm, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_STNT1H_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89450,8 +88278,7 @@ function decode_STNT1W_Z_P_AR_D_64_unscaled (msz, Rm, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_STNT1W_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89528,8 +88355,7 @@ function decode_STNT1D_Z_P_AR_D_64_unscaled (msz, Rm, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_STNT1D_Z_P_AR_D_64_unscaled(2048, esize, g, m, msize, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89603,8 +88429,7 @@ function decode_LD1Q_Z_P_AR_D_64_unscaled (Rm, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_LD1Q_Z_P_AR_D_64_unscaled(2048, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89677,8 +88502,7 @@ function decode_ST1Q_Z_P_AR_D_64_unscaled (Rm, Pg, Zn, Zt) = {
       },
       2048 => {
           execute_ST1Q_Z_P_AR_D_64_unscaled(2048, g, m, n, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89769,8 +88593,7 @@ function decode_LD1B_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1B_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89863,8 +88686,7 @@ function decode_LD1H_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1H_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -89957,8 +88779,7 @@ function decode_LD1W_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1W_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90051,8 +88872,7 @@ function decode_LD1D_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1D_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90145,8 +88965,7 @@ function decode_LD1B_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1B_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90239,8 +89058,7 @@ function decode_LD1H_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1H_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90333,8 +89151,7 @@ function decode_LD1W_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1W_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90427,8 +89244,7 @@ function decode_LD1D_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1D_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90521,8 +89337,7 @@ function decode_LDNT1B_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1B_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90615,8 +89430,7 @@ function decode_LDNT1H_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1H_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90709,8 +89523,7 @@ function decode_LDNT1W_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1W_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90803,8 +89616,7 @@ function decode_LDNT1D_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1D_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90897,8 +89709,7 @@ function decode_LDNT1B_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1B_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -90991,8 +89802,7 @@ function decode_LDNT1H_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1H_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91085,8 +89895,7 @@ function decode_LDNT1W_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1W_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91179,8 +89988,7 @@ function decode_LDNT1D_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1D_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91270,8 +90078,7 @@ function decode_ST1B_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1B_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91361,8 +90168,7 @@ function decode_ST1H_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1H_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91452,8 +90258,7 @@ function decode_ST1W_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1W_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91543,8 +90348,7 @@ function decode_ST1D_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1D_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91634,8 +90438,7 @@ function decode_ST1B_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1B_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91725,8 +90528,7 @@ function decode_ST1H_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1H_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91816,8 +90618,7 @@ function decode_ST1W_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1W_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91907,8 +90708,7 @@ function decode_ST1D_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1D_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -91998,8 +90798,7 @@ function decode_STNT1B_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1B_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92089,8 +90888,7 @@ function decode_STNT1H_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1H_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92180,8 +90978,7 @@ function decode_STNT1W_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1W_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92271,8 +91068,7 @@ function decode_STNT1D_MZ_P_BR_2 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1D_MZ_P_BR_2(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92362,8 +91158,7 @@ function decode_STNT1B_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1B_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92453,8 +91248,7 @@ function decode_STNT1H_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1H_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92544,8 +91338,7 @@ function decode_STNT1W_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1W_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92635,8 +91428,7 @@ function decode_STNT1D_MZ_P_BR_4 (Rm, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1D_MZ_P_BR_4(2048, esize, g, m, n, nreg, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92727,8 +91519,7 @@ function decode_LD1B_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1B_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92819,8 +91610,7 @@ function decode_LD1H_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1H_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -92911,8 +91701,7 @@ function decode_LD1W_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1W_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93003,8 +91792,7 @@ function decode_LD1D_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1D_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93095,8 +91883,7 @@ function decode_LD1B_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1B_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93187,8 +91974,7 @@ function decode_LD1H_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1H_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93279,8 +92065,7 @@ function decode_LD1W_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1W_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93371,8 +92156,7 @@ function decode_LD1D_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LD1D_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93463,8 +92247,7 @@ function decode_LDNT1B_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1B_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93555,8 +92338,7 @@ function decode_LDNT1H_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1H_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93647,8 +92429,7 @@ function decode_LDNT1W_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1W_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93739,8 +92520,7 @@ function decode_LDNT1D_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1D_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93831,8 +92611,7 @@ function decode_LDNT1B_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1B_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -93923,8 +92702,7 @@ function decode_LDNT1H_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1H_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94015,8 +92793,7 @@ function decode_LDNT1W_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1W_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94107,8 +92884,7 @@ function decode_LDNT1D_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_LDNT1D_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94196,8 +92972,7 @@ function decode_ST1B_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1B_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94285,8 +93060,7 @@ function decode_ST1H_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1H_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94374,8 +93148,7 @@ function decode_ST1W_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1W_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94463,8 +93236,7 @@ function decode_ST1D_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1D_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94552,8 +93324,7 @@ function decode_ST1B_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1B_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94641,8 +93412,7 @@ function decode_ST1H_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1H_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94730,8 +93500,7 @@ function decode_ST1W_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1W_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94819,8 +93588,7 @@ function decode_ST1D_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_ST1D_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94908,8 +93676,7 @@ function decode_STNT1B_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1B_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -94997,8 +93764,7 @@ function decode_STNT1H_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1H_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -95086,8 +93852,7 @@ function decode_STNT1W_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1W_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -95175,8 +93940,7 @@ function decode_STNT1D_MZ_P_BI_2 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1D_MZ_P_BI_2(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -95264,8 +94028,7 @@ function decode_STNT1B_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1B_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -95353,8 +94116,7 @@ function decode_STNT1H_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1H_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -95442,8 +94204,7 @@ function decode_STNT1W_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1W_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 
@@ -95531,8 +94292,7 @@ function decode_STNT1D_MZ_P_BI_4 (imm4, msz, PNg, Rn, Zt, N) = {
       },
       2048 => {
           execute_STNT1D_MZ_P_BI_4(2048, esize, g, n, nreg, offset, t)
-      },
-      _ => ()
+      }
     }
 }
 

--- a/arm-v9.4-a/src/prelude.sail
+++ b/arm-v9.4-a/src/prelude.sail
@@ -83,9 +83,6 @@ function min_real(n, m) = (if n <= m then n else m)
 
 overload Min = {min_int, min_real}
 
-val max_int : forall 'n 'm. (int('n), int('m)) -> {'o, ('n <= 'm & 'o == 'm) | ('n > 'm & 'o == 'n). int('o)}
-function max_int(n, m) = (if n <= m then m else n)
-
 val max_real : (real, real) -> real
 function max_real(n, m) = (if n <= m then m else n)
 
@@ -113,8 +110,6 @@ overload DIV = {ediv_nat, fdiv_int}
 overload MOD = {emod_nat, fmod_int}
 overload QUOT = {tdiv_int}
 overload REM = {tmod_int}
-
-val pow2 = pure "pow2" : forall 'n, 'n >= 0. int('n) -> int(2 ^ 'n)
 
 overload operator ^ = {pow_real}
 
@@ -286,6 +281,12 @@ function ThrowSError(iesb_req) = throw(Error_SError(iesb_req))
 val ReservedEncoding : unit -> unit
 function ReservedEncoding() = throw(Error_ReservedEncoding())
 
+val PatternMatchFailure : forall ('a : Type). string -> 'a
+function PatternMatchFailure(location) = {
+  assert(false, concat_str("Pattern match failure in ", location));
+  exit()
+}
+
 val DecStr = pure "dec_str" : int -> string
 
 val HexStr = pure "hex_str" : int -> string
@@ -293,20 +294,17 @@ val HexStr = pure "hex_str" : int -> string
 val BoolStr : bool -> string
 function BoolStr b = match b { true => "true", false => "false" }
 
-val append_str = pure {ocaml: "concat_str", interpreter: "concat_str", lem: "stringAppend", c: "concat_str", coq: "String.append" } :
-  (string, string) -> string
-
 function append_int(str: string, n: int) -> string = {
-  append_str(str, DecStr(n))
+  concat_str(str, DecStr(n))
 }
 
 function append_bool(str: string, b: bool) -> string = {
-  append_str(str, if b then "true" else "false")
+  concat_str(str, if b then "true" else "false")
 }
 
 infixl 4 ++
 
-overload operator ++ = {append_int, append_bool, append_str}
+overload operator ++ = {append_int, append_bool, concat_str}
 
 val print_integer : int -> unit
 function print_integer(i) = print_int("", i)

--- a/arm-v9.4-a/src/reset.sail
+++ b/arm-v9.4-a/src/reset.sail
@@ -102,9 +102,7 @@ function EncodeVARange () = {
           assert(Have56BitVAExt());
           return(0b0001)
       },
-      _ => {
-          return(undefined : bits(4))
-      }
+      _ => PatternMatchFailure("EncodeVARange")
     }
 }
 
@@ -1425,7 +1423,7 @@ function TakeReset cold = {
           ? if ? == EL1 => {
               assert(ID_AA64PFR0_EL1[EL1] == 0b0010)
           },
-          _ => ()
+          _ => PatternMatchFailure("TakeReset")
         };
         __highest_el_aarch32 = true;
         FeatureImpl[num_of_Feature(FEAT_AA64EL0)] = false;

--- a/arm-v9.4-a/src/sysregs.sail
+++ b/arm-v9.4-a/src/sysregs.sail
@@ -242,7 +242,7 @@ function getCacheID (level, data_cache) = {
           assert(constraint((0 <= 'level & 'level < 7)));
           ccsidr_val = __DCACHE_CCSIDR_RESET[level]
       },
-      _ => ()
+      _ => PatternMatchFailure("getCacheID")
     };
     return(ccsidr_val)
 }

--- a/arm-v9.4-a/src/v8_base.sail
+++ b/arm-v9.4-a/src/v8_base.sail
@@ -5074,7 +5074,7 @@ function CountPMUEvents idx = {
             SS_Realm => {
                 filtered = U != RLU
             },
-            _ => ()
+            _ => PatternMatchFailure("CountPMUEvents")
           }
       },
       ? if ? == EL1 => {
@@ -5088,7 +5088,7 @@ function CountPMUEvents idx = {
             SS_Realm => {
                 filtered = P != RLK
             },
-            _ => ()
+            _ => PatternMatchFailure("CountPMUEvents")
           }
       },
       ? if ? == EL2 => {
@@ -5102,7 +5102,7 @@ function CountPMUEvents idx = {
             SS_Realm => {
                 filtered = NSH == RLH
             },
-            _ => ()
+            _ => PatternMatchFailure("CountPMUEvents")
           }
       },
       ? if ? == EL3 => {
@@ -5112,7 +5112,7 @@ function CountPMUEvents idx = {
               filtered = P == 0b1
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("CountPMUEvents")
     };
     return((((not_bool(debug) & enabled) & not_bool(prohibited)) & not_bool(filtered)) & not_bool(frozen))
 }
@@ -5428,7 +5428,7 @@ function PMUCountValue (n, Vb) = {
       0b11 => {
           Vc = Vb < T
       },
-      _ => ()
+      _ => PatternMatchFailure("PMUCountValue")
     };
     Vt : int = undefined;
     if [PMEVTYPER_EL0[n][TC][0]] == 0b0 then {
@@ -5867,9 +5867,7 @@ function BranchRecordAllowed el = {
               return(BRBCR_EL1[E0BRE] == 0b1)
           }
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("BranchRecordAllowed")
     }
 }
 
@@ -6098,7 +6096,7 @@ function EffectiveTBI (address, IsInstr, el) = {
           };
           ()
       },
-      _ => ()
+      _ => PatternMatchFailure("EffectiveTBI")
     };
     return(if tbi == 0b1 & ((not_bool(HavePACExt()) | tbid == 0b0) | not_bool(IsInstr)) then
       0b1
@@ -6588,7 +6586,7 @@ function ProfilingBufferOwner () = {
           [bitone, bitone, _] => {
               owning_ss = SS_Realm
           },
-          _ => ()
+          _ => PatternMatchFailure("ProfilingBufferOwner")
         }
     } else {
         owning_ss = if SecureOnlyImplementation() then SS_Secure else
@@ -6629,7 +6627,7 @@ function ProfilingBufferEnabled () = {
       SS_Realm => {
           state_match = state_bits == 0b11
       },
-      _ => ()
+      _ => PatternMatchFailure("ProfilingBufferEnabled")
     };
     return(((not_bool(ELUsingAArch32(owning_el)) & state_match) & PMBLIMITR_EL1[E] == 0b1) & PMBSR_EL1[S] == 0b0)
 }
@@ -6667,7 +6665,7 @@ function StatisticalProfilingEnabled__1 el = {
       ? if ? == EL0 => {
           spe_bit = if tge_set then PMSCR_EL2[E0HSPE] else PMSCR_EL1[E0SPE]
       },
-      _ => ()
+      _ => PatternMatchFailure("StatisticalProfilingEnabled__1")
     };
     return(spe_bit == 0b1)
 }
@@ -7390,7 +7388,7 @@ function SP_set value_name = {
           ? if ? == EL3 => {
               SP_EL3 = value_name
           },
-          _ => ()
+          _ => PatternMatchFailure("SP_set")
         }
     };
     return()
@@ -7482,7 +7480,7 @@ function RestoreTransactionCheckpointParameterised (vl, pl) = {
           ? if ? == EL3 => {
               GCSPR_EL3 = Mk_GCSPR_EL3_Type(TSTATE.GCSPR_ELx)
           },
-          _ => ()
+          _ => PatternMatchFailure("RestoreTransactionCheckpointParameterised")
         }
     };
     return()
@@ -7963,9 +7961,6 @@ function HaltingAllowed () = {
       },
       SS_Realm => {
           return(ExternalRealmInvasiveDebugEnabled())
-      },
-      _ => {
-          return(undefined : bool)
       }
     }
 }
@@ -8212,9 +8207,7 @@ function GetCurrentEXLOCKEN () = {
       ? if ? == EL3 => {
           return(GCSCR_EL3[EXLOCKEN] == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("GetCurrentEXLOCKEN")
     }
 }
 
@@ -8922,9 +8915,7 @@ function PLOfEL el = {
       ? if ? == EL0 => {
           return(PL0)
       },
-      _ => {
-          return(undefined : PrivilegeLevel)
-      }
+      _ => PatternMatchFailure("PLOfEL")
     }
 }
 
@@ -9961,7 +9952,7 @@ function BRBEException (erec, preferred_exception_return, target_address_in, tar
           };
           ()
       },
-      _ => ()
+      _ => PatternMatchFailure("BRBEException")
     };
     let source_valid : bool = BranchRecordAllowed(PSTATE.EL);
     let target_valid : bool = BranchRecordAllowed(target_el);
@@ -10671,7 +10662,7 @@ function AArch64_CheckForWFxTrap (target_el, wfxtype) = {
       ? if ? == EL3 => {
           trap = (if is_wfe then SCR_EL3[TWE] else SCR_EL3[TWI]) == 0b1
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_CheckForWFxTrap")
     };
     if trap then {
         AArch64_WFxTrap(wfxtype, target_el)
@@ -10730,7 +10721,7 @@ function WFETrapDelay target_el = {
           delay_enabled = SCR_EL3[TWEDEn] == 0b1;
           delay = (1 << (UInt(SCR_EL3[TWEDEL]) + 8))
       },
-      _ => ()
+      _ => PatternMatchFailure("WFETrapDelay")
     };
     let 'delay = delay;
     return((delay_enabled, delay))
@@ -10939,7 +10930,7 @@ function GCSPCRSelected el = {
       ? if ? == EL3 => {
           return(GCSCR_EL3[PCRSEL] == 0b1)
       },
-      _ => ()
+      _ => PatternMatchFailure("GCSPCRSelected")
     };
     Unreachable();
     return(true)
@@ -11075,7 +11066,7 @@ function EffectiveTCMA (address, el) = {
       ? if ? == EL3 => {
           tcma = TCR_EL3[TCMA]
       },
-      _ => ()
+      _ => PatternMatchFailure("EffectiveTCMA")
     };
     return(tcma)
 }
@@ -11113,7 +11104,7 @@ function EffectiveMTX (address, is_instr, el) = {
           ? if ? == EL3 => {
               mtx = TCR_EL3[MTX]
           },
-          _ => ()
+          _ => PatternMatchFailure("EffectiveMTX")
         }
     };
     return(mtx)
@@ -11210,9 +11201,7 @@ function MPAMisEnabled () = {
       ? if ? == EL1 => {
           return(MPAM1_EL1_read()[MPAMEN] == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("MPAMisEnabled")
     }
 }
 
@@ -12413,9 +12402,6 @@ function CPASAtPAS pas = {
       },
       PAS_Realm => {
           return(CPAS_Realm)
-      },
-      _ => {
-          return(undefined : CachePASpace)
       }
     }
 }
@@ -12435,9 +12421,6 @@ function CPASAtSecurityState ss = {
       },
       SS_Realm => {
           return(CPAS_RealmNonSecure)
-      },
-      _ => {
-          return(undefined : CachePASpace)
       }
     }
 }
@@ -12783,9 +12766,6 @@ function TargetSecurityState (NS, NSE) = {
           },
           0b1 => {
               return(SS_NonSecure)
-          },
-          _ => {
-              return(undefined : SecurityState)
           }
         }
     } else if HaveRME() then {
@@ -12802,9 +12782,6 @@ function TargetSecurityState (NS, NSE) = {
               },
               0b10 => {
                   return(SS_Root)
-              },
-              _ => {
-                  return(undefined : SecurityState)
               }
             }
         } else if curr_ss == SS_Realm then {
@@ -14909,7 +14886,7 @@ function AArch64_RouteToSErrorOffset target_el = {
               ease_bit = 0b0
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_RouteToSErrorOffset")
     };
     return(ease_bit == 0b1)
 }
@@ -15076,9 +15053,7 @@ function ReportAsGPCException fault = {
       GPCF_Fail => {
           return(SCR_EL3[GPF] == 0b1 & PSTATE.EL != EL3)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("ReportAsGPCException")
     }
 }
 
@@ -15099,9 +15074,7 @@ function EncodeGPCSC gpcf = {
       GPCF_EABT => {
           return(0b01010 @ [gpcf.level[0]])
       },
-      _ => {
-          return(undefined : bits(6))
-      }
+      _ => PatternMatchFailure("EncodeGPCSC")
     }
 }
 
@@ -15734,7 +15707,7 @@ function FPRoundBase__1 (op, fpcr, rounding, isbfloat16, fpexc, N) = {
               round_up = false;
               overflow_to_inf = false
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRoundBase__1")
         };
         if round_up_unconstrained then {
             int_mant_unconstrained = int_mant_unconstrained + 1;
@@ -15783,7 +15756,7 @@ function FPRoundBase__1 (op, fpcr, rounding, isbfloat16, fpexc, N) = {
               round_up = false;
               overflow_to_inf = false
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRoundBase__1")
         }
     };
     if round_up then {
@@ -15850,9 +15823,6 @@ function FPDecodeRounding rmode = {
       },
       0b11 => {
           return(FPRounding_ZERO)
-      },
-      _ => {
-          return(undefined : FPRounding)
       }
     }
 }
@@ -16157,7 +16127,7 @@ function FPProcessNaN__1 (fptype, op, fpcr, fpexc) = {
       64 => {
           topfrac = 51
       },
-      _ => ()
+      _ => PatternMatchFailure("FPProcessNaN__1")
     };
     let 'topfrac = topfrac;
     result : bits('N) = op;
@@ -16426,7 +16396,7 @@ function FPConvertNaN (op, M) = {
       16 => {
           frac = op[8 .. 0] @ Zeros(42)
       },
-      _ => ()
+      _ => PatternMatchFailure("FPConvertNaN")
     };
     match M {
       64 => {
@@ -16438,7 +16408,7 @@ function FPConvertNaN (op, M) = {
       16 => {
           result = (sign @ Ones(M - 10)) @ frac[50 .. 42]
       },
-      _ => ()
+      _ => PatternMatchFailure("FPConvertNaN")
     };
     return(result)
 }
@@ -17287,7 +17257,7 @@ function FPRecipEstimate (operand, fpcr_in) = {
           FPRounding_ZERO => {
               overflow_to_inf = false
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRecipEstimate")
         };
         result = if overflow_to_inf then FPInfinity(sign, 'N) else
           FPMaxNormal(sign, 'N);
@@ -17322,7 +17292,7 @@ function FPRecipEstimate (operand, fpcr_in) = {
               fraction = operand[51 .. 0];
               exp = UInt(operand[62 .. 52])
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRecipEstimate")
         };
         if exp == 0 then {
             if [fraction[51]] == 0b0 then {
@@ -17352,7 +17322,7 @@ function FPRecipEstimate (operand, fpcr_in) = {
           64 => {
               result_exp = 2045 - exp
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRecipEstimate")
         };
         let 'estimate = RecipEstimate(scaled, increasedprecision_name);
         if not_bool(increasedprecision_name) then {
@@ -17377,7 +17347,7 @@ function FPRecipEstimate (operand, fpcr_in) = {
           64 => {
               result = (sign @ result_exp['N - 54 .. 0]) @ fraction[51 .. 0]
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRecipEstimate")
         }
     };
     return(result)
@@ -17402,7 +17372,7 @@ function FPRecpX (op, fpcr_in) = {
       64 => {
           esize = 11
       },
-      _ => ()
+      _ => PatternMatchFailure("FPRecpX")
     };
     let 'esize = esize;
     result : bits('N) = undefined;
@@ -17426,7 +17396,7 @@ function FPRecpX (op, fpcr_in) = {
       64 => {
           exp = op[52 + esize - 1 .. 52]
       },
-      _ => ()
+      _ => PatternMatchFailure("FPRecpX")
     };
     let max_exp : bits('esize) = Ones(esize) - 1;
     if fptype == FPType_SNaN | fptype == FPType_QNaN then {
@@ -17484,7 +17454,7 @@ function FPRoundInt (op, fpcr, rounding, exact) = {
           FPRounding_TIEAWAY => {
               round_up = error > 0.5 | error == 0.5 & int_result >= 0
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRoundInt")
         };
         if round_up then {
             int_result = int_result + 1
@@ -17556,7 +17526,7 @@ function FPRoundIntN (op, fpcr, rounding, intsize) = {
           FPRounding_TIEAWAY => {
               round_up = error > 0.5 | error == 0.5 & int_result >= 0
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRoundIntN")
         };
         if round_up then {
             int_result = int_result + 1
@@ -17638,7 +17608,7 @@ function FPRSqrtEstimate (operand, fpcr_in) = {
               fraction = operand[51 .. 0];
               exp = UInt(operand[62 .. 52])
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRSqrtEstimate")
         };
         if exp == 0 then {
             while [fraction[51]] == 0b0 do {
@@ -17676,7 +17646,7 @@ function FPRSqrtEstimate (operand, fpcr_in) = {
           64 => {
               result_exp = DIV(3068 - exp, 2)
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRSqrtEstimate")
         };
         let 'result_exp = result_exp;
         let 'estimate = RecipSqrtEstimate(scaled, increasedprecision_name);
@@ -17694,7 +17664,7 @@ function FPRSqrtEstimate (operand, fpcr_in) = {
           64 => {
               result = ((0b0 @ result_exp['N - 54 .. 0]) @ estimate[7 .. 0]) @ Zeros(44)
           },
-          _ => ()
+          _ => PatternMatchFailure("FPRSqrtEstimate")
         }
     };
     return(result)
@@ -17856,7 +17826,7 @@ function FPToFixed (op, fbits, is_unsigned, fpcr, rounding, M) = {
       FPRounding_TIEAWAY => {
           round_up = error > 0.5 | error == 0.5 & int_result >= 0
       },
-      _ => ()
+      _ => PatternMatchFailure("FPToFixed")
     };
     if round_up then {
         int_result = int_result + 1
@@ -18884,9 +18854,6 @@ function PAREncodeShareability memattrs = {
       },
       Shareability_OSH => {
           return(0b10)
-      },
-      _ => {
-          return(undefined : bits(2))
       }
     }
 }
@@ -18981,9 +18948,7 @@ function DecodeShareability sh = {
             Constraint_NSH => {
                 return(Shareability_NSH)
             },
-            _ => {
-                return(undefined : Shareability)
-            }
+            _ => PatternMatchFailure("DecodeShareability")
           }
       }
     }
@@ -19026,9 +18991,6 @@ function DecodeDevice device = {
       },
       0b11 => {
           return(DeviceType_GRE)
-      },
-      _ => {
-          return(undefined : DeviceType)
       }
     }
 }
@@ -19138,7 +19100,7 @@ function S2DecodeCacheability attr = {
             Constraint_WB => {
                 s2attr.attrs = MemAttr_WB
             },
-            _ => ()
+            _ => PatternMatchFailure("S2DecodeCacheability")
           }
       }
     };
@@ -19966,9 +19928,6 @@ function ContiguousSize (d128, tgx, level) = {
           TGx_64KB => {
               assert(level == 2 | level == 3);
               return(if level == 2 then 6 else 4)
-          },
-          _ => {
-              return(undefined : int)
           }
         }
     } else {
@@ -19984,9 +19943,6 @@ function ContiguousSize (d128, tgx, level) = {
           TGx_64KB => {
               assert(level == 2 | level == 3);
               return(5)
-          },
-          _ => {
-              return(undefined : int)
           }
         }
     }
@@ -20004,9 +19960,6 @@ function TGxGranuleBits tgx = {
       },
       TGx_64KB => {
           return(16)
-      },
-      _ => {
-          return(undefined : int)
       }
     }
 }
@@ -20058,9 +20011,6 @@ function RegimeUsingAArch32 regime = {
       },
       Regime_EL3 => {
           return(false)
-      },
-      _ => {
-          return(undefined : bool)
       }
     }
 }
@@ -20083,9 +20033,6 @@ function SecurityStateForRegime regime = {
       },
       Regime_EL10 => {
           return(SecurityStateAtEL(EL1))
-      },
-      _ => {
-          return(undefined : SecurityState)
       }
     }
 }
@@ -20105,9 +20052,6 @@ function DecodePASpace (nse, ns) = {
       },
       0b11 => {
           return(PAS_Realm)
-      },
-      _ => {
-          return(undefined : PASpace)
       }
     }
 }
@@ -20262,9 +20206,6 @@ function AArch64_HaveS1TG tgx = {
       },
       TGx_64KB => {
           return(__IMPDEF_boolean("Has 64K Translation Granule"))
-      },
-      _ => {
-          return(undefined : bool)
       }
     }
 }
@@ -20287,7 +20228,7 @@ function AArch64_S1DecodeTG0 tg0_in = {
       0b10 => {
           tgx = TGx_16KB
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_S1DecodeTG0")
     };
     if not_bool(AArch64_HaveS1TG(tgx)) then {
         match __IMPDEF_bits(2, "TG0 encoded granule size") {
@@ -20300,7 +20241,7 @@ function AArch64_S1DecodeTG0 tg0_in = {
           0b10 => {
               tgx = TGx_16KB
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch64_S1DecodeTG0")
         }
     };
     return(tgx)
@@ -20324,7 +20265,7 @@ function AArch64_S1DecodeTG1 tg1_in = {
       0b01 => {
           tgx = TGx_16KB
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_S1DecodeTG1")
     };
     if not_bool(AArch64_HaveS1TG(tgx)) then {
         match __IMPDEF_bits(2, "TG1 encoded granule size") {
@@ -20337,7 +20278,7 @@ function AArch64_S1DecodeTG1 tg1_in = {
           0b01 => {
               tgx = TGx_16KB
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch64_S1DecodeTG1")
         }
     };
     return(tgx)
@@ -20526,7 +20467,7 @@ function AArch64_S1TTWParamsEL10 varange = {
               Constraint_NVNV1_11 => {
                   walkparams.nv1 = 0b1
               },
-              _ => ()
+              _ => PatternMatchFailure("AArch64_S1TTWParamsEL10")
             }
         } else {
             walkparams.nv1 = HCR_EL2[NV1]
@@ -21002,7 +20943,7 @@ function AArch64_GetS1TTWParams (regime, ss, va) = {
       Regime_EL10 => {
           walkparams = AArch64_S1TTWParamsEL10(varange)
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_GetS1TTWParams")
     };
     return(walkparams)
 }
@@ -21192,7 +21133,7 @@ function PACInvSub Tinput = {
           0b1111 => {
               Toutput[4 * i + 3 .. 4 * i] = 0b0011
           },
-          _ => ()
+          _ => PatternMatchFailure("PACInvSub")
         }
     };
     return(Toutput)
@@ -21288,7 +21229,7 @@ function PACSub Tinput = {
           0b1111 => {
               Toutput[4 * i + 3 .. 4 * i] = 0b1010
           },
-          _ => ()
+          _ => PatternMatchFailure("PACSub")
         }
     };
     return(Toutput)
@@ -21348,7 +21289,7 @@ function PACSub1 Tinput = {
           0b1111 => {
               Toutput[4 * i + 3 .. 4 * i] = 0b0100
           },
-          _ => ()
+          _ => PatternMatchFailure("PACSub1")
         }
     };
     return(Toutput)
@@ -21828,7 +21769,7 @@ function AddPACIA (x, y) = {
           TrapEL2 = false;
           TrapEL3 = false
       },
-      _ => ()
+      _ => PatternMatchFailure("AddPACIA")
     };
     if Enable == 0b0 then {
         return(x)
@@ -21888,7 +21829,7 @@ function AddPACIB (x, y) = {
           TrapEL2 = false;
           TrapEL3 = false
       },
-      _ => ()
+      _ => PatternMatchFailure("AddPACIB")
     };
     if Enable == 0b0 then {
         return(x)
@@ -21948,7 +21889,7 @@ function AddPACDA (x, y) = {
           TrapEL2 = false;
           TrapEL3 = false
       },
-      _ => ()
+      _ => PatternMatchFailure("AddPACDA")
     };
     if Enable == 0b0 then {
         return(x)
@@ -22008,7 +21949,7 @@ function AddPACDB (x, y) = {
           TrapEL2 = false;
           TrapEL3 = false
       },
-      _ => ()
+      _ => PatternMatchFailure("AddPACDB")
     };
     if Enable == 0b0 then {
         return(x)
@@ -22063,7 +22004,7 @@ function AddPACGA (x, y) = {
           TrapEL2 = false;
           TrapEL3 = false
       },
-      _ => ()
+      _ => PatternMatchFailure("AddPACGA")
     };
     if TrapEL3 & EL3SDDUndefPriority() then {
         throw(Error_Undefined());
@@ -22114,7 +22055,7 @@ function AuthIA (x, y, is_combined) = {
           TrapEL2 = false;
           TrapEL3 = false
       },
-      _ => ()
+      _ => PatternMatchFailure("AuthIA")
     };
     if Enable == 0b0 then {
         return(x)
@@ -22167,7 +22108,7 @@ function AuthIB (x, y, is_combined) = {
           TrapEL2 = false;
           TrapEL3 = false
       },
-      _ => ()
+      _ => PatternMatchFailure("AuthIB")
     };
     if Enable == 0b0 then {
         return(x)
@@ -22220,7 +22161,7 @@ function AuthDA (x, y, is_combined) = {
           TrapEL2 = false;
           TrapEL3 = false
       },
-      _ => ()
+      _ => PatternMatchFailure("AuthDA")
     };
     if Enable == 0b0 then {
         return(x)
@@ -22273,7 +22214,7 @@ function AuthDB (x, y, is_combined) = {
           TrapEL2 = false;
           TrapEL3 = false
       },
-      _ => ()
+      _ => PatternMatchFailure("AuthDB")
     };
     if Enable == 0b0 then {
         return(x)
@@ -22588,9 +22529,6 @@ function BTypeCompatible_BTI hintcode = {
       },
       0b11 => {
           return(true)
-      },
-      _ => {
-          return(undefined : bool)
       }
     }
 }
@@ -22755,9 +22693,7 @@ function SP_read () = {
           ? if ? == EL3 => {
               return(SP_EL3)
           },
-          _ => {
-              return(undefined : bits(64))
-          }
+          _ => PatternMatchFailure("SP_read")
         }
     }
 }
@@ -22989,7 +22925,7 @@ function AArch64_ReportTagCheckFault (el, ttbr) = {
               TFSRE0_EL1[TF1] = 0b1
           }
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_ReportTagCheckFault")
     }
 }
 
@@ -23317,7 +23253,7 @@ function AArch64_BreakpointValueMatch (n_in, vaddress, linked_to, isbreakpnt) = 
               Constraint_NONE => {
                   mask = 0
               },
-              _ => ()
+              _ => PatternMatchFailure("AArch64_BreakpointValueMatch")
             }
         };
         if mask != 0 then {
@@ -23528,7 +23464,7 @@ function AArch64_StateMatch (ssc_in, ssce_in, hmc_in, pxc_in, linked_in, linked_
       ? if ? == EL0 => {
           priv_match = EL0_match
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_StateMatch")
     };
     ss_match : bool = undefined;
     match ssce @ ssc {
@@ -23547,7 +23483,7 @@ function AArch64_StateMatch (ssc_in, ssce_in, hmc_in, pxc_in, linked_in, linked_
       0b101 => {
           ss_match = accdesc.ss == SS_Realm
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_StateMatch")
     };
     linked_match : bool = false;
     is_linked_mismatch : bool = false;
@@ -23565,7 +23501,7 @@ function AArch64_StateMatch (ssc_in, ssce_in, hmc_in, pxc_in, linked_in, linked_
               Constraint_NONE => {
                   linked = false
               },
-              _ => ()
+              _ => PatternMatchFailure("AArch64_StateMatch")
             }
         };
         ()
@@ -23722,7 +23658,7 @@ function AArch64_WatchpointByteMatch (n, vaddress) = {
           Constraint_NONE => {
               mask = 0
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch64_WatchpointByteMatch")
         }
     };
     let 'mask = mask;
@@ -23781,7 +23717,7 @@ function AArch64_WatchpointMatch (n, vaddress, size, accdesc) = {
       0b11 => {
           ls_match = true
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_WatchpointMatch")
     };
     value_match_name : bool = false;
     foreach (byte from 0 to (size - 1) by 1 in inc) {
@@ -24018,9 +23954,7 @@ function AArch64_S1E0POEnabled (regime, nv1) = {
       Regime_EL10 => {
           return((IsTCR2EL1Enabled() & nv1 == 0b0) & TCR2_EL1[E0POE] == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("AArch64_S1E0POEnabled")
     }
 }
 
@@ -24274,9 +24208,7 @@ function AArch64_S1POR regime = {
       Regime_EL10 => {
           return(Mk_S1PORType(POR_EL1.bits))
       },
-      _ => {
-          return(undefined : S1PORType)
-      }
+      _ => PatternMatchFailure("AArch64_S1POR")
     }
 }
 
@@ -24406,9 +24338,7 @@ function AArch64_S1POEnabled regime = {
       Regime_EL10 => {
           return(IsTCR2EL1Enabled() & TCR2_EL1[POE] == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("AArch64_S1POEnabled")
     }
 }
 
@@ -24543,9 +24473,7 @@ function AArch64_S1DCacheEnabled regime = {
       Regime_EL10 => {
           return(SCTLR_EL1[C] == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("AArch64_S1DCacheEnabled")
     }
 }
 
@@ -24622,9 +24550,7 @@ function AArch64_S1ICacheEnabled regime = {
       Regime_EL10 => {
           return(SCTLR_EL1[I] == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("AArch64_S1ICacheEnabled")
     }
 }
 
@@ -24746,9 +24672,7 @@ function AArch64_S1Enabled (regime, acctype) = {
       Regime_EL10 => {
           return((not_bool(EL2Enabled()) | (HCR_EL2[DC] @ HCR_EL2[TGE]) == 0b00) & SCTLR_EL1[M] == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("AArch64_S1Enabled")
     }
 }
 
@@ -24812,9 +24736,7 @@ function AArch64_S1OutputMECID (walkparams, regime, varange, paspace, descriptor
       Regime_EL10 => {
           return(VMECID_P_EL2[MECID])
       },
-      _ => {
-          return(undefined : bits(16))
-      }
+      _ => PatternMatchFailure("AArch64_S1OutputMECID")
     }
 }
 
@@ -25035,7 +24957,7 @@ function AArch64_GetS1TLBContext (regime, ss, va, tg) = {
       Regime_EL10 => {
           tlbcontext = AArch64_TLBContextEL10(ss, va, tg)
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_GetS1TLBContext")
     };
     tlbcontext.includes_s1_name = true;
     tlbcontext.includes_s2_name = false;
@@ -25127,9 +25049,7 @@ function AArch64_S1EPD (regime, va) = {
           return(if varange == VARange_LOWER then TCR_EL1[EPD0] else
             TCR_EL1[EPD1])
       },
-      _ => {
-          return(undefined : bits(1))
-      }
+      _ => PatternMatchFailure("AArch64_S1EPD")
     }
 }
 
@@ -25173,9 +25093,7 @@ function AArch64_S1TTBR (regime, va) = {
               return(ZeroExtend(TTBR1_EL1_read().bits, 128))
           }
       },
-      _ => {
-          return(undefined : bits(128))
-      }
+      _ => PatternMatchFailure("AArch64_S1TTBR")
     }
 }
 
@@ -25679,9 +25597,6 @@ function AArch64_HaveS2TG tgx = {
           },
           TGx_64KB => {
               return(__IMPDEF_boolean("Has Stage 2 64K Translation Granule"))
-          },
-          _ => {
-              return(undefined : bool)
           }
         }
     } else {
@@ -25707,7 +25622,7 @@ function AArch64_S2DecodeTG0 tg0_in = {
       0b10 => {
           tgx = TGx_16KB
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_S2DecodeTG0")
     };
     if not_bool(AArch64_HaveS2TG(tgx)) then {
         match __IMPDEF_bits(2, "TG0 encoded granule size") {
@@ -25720,7 +25635,7 @@ function AArch64_S2DecodeTG0 tg0_in = {
           0b10 => {
               tgx = TGx_16KB
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch64_S2DecodeTG0")
         }
     };
     return(tgx)
@@ -26397,9 +26312,7 @@ function AArch64_S2StartLevel walkparams = {
             0b100 => {
                 return(negate(1))
             },
-            _ => {
-                return(undefined : int)
-            }
+            _ => PatternMatchFailure("AArch64_S2StartLevel")
           }
       },
       TGx_16KB => {
@@ -26415,9 +26328,6 @@ function AArch64_S2StartLevel walkparams = {
             },
             0b11 => {
                 return(0)
-            },
-            _ => {
-                return(undefined : int)
             }
           }
       },
@@ -26432,13 +26342,8 @@ function AArch64_S2StartLevel walkparams = {
             0b10 => {
                 return(1)
             },
-            _ => {
-                return(undefined : int)
-            }
+            _ => PatternMatchFailure("AArch64_S2StartLevel")
           }
-      },
-      _ => {
-          return(undefined : int)
       }
     }
 }
@@ -26505,9 +26410,6 @@ function AArch64_S2InvalidSL walkparams = {
                 return(false)
             }
           }
-      },
-      _ => {
-          return(undefined : bool)
       }
     }
 }
@@ -26710,7 +26612,7 @@ function AArch64_S2InitialTTWState (ss, walkparams) = {
       SS_Realm => {
           tablebase.paspace = PAS_Realm
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_S2InitialTTWState")
     };
     tablebase.address = AArch64_S2TTBaseAddress(walkparams, tablebase.paspace, ttbr);
     walkstate.baseaddress = tablebase;
@@ -28366,7 +28268,7 @@ function MemAtomic (address, cmpoperand, operand, accdesc_in) = {
           newvalue = operand;
           cmpfail = cmpoperand != oldvalue
       },
-      _ => ()
+      _ => PatternMatchFailure("MemAtomic")
     };
     if HaveMTEStoreOnlyExt() & StoreOnlyTagCheckingEnabled(accdesc.el) then {
         if accdesc.tagchecked & cmpfail then {
@@ -28421,7 +28323,7 @@ function IsD128Enabled el = {
           ? if ? == EL3 => {
               d128enabled = TCR_EL3[D128] == 0b1
           },
-          _ => ()
+          _ => PatternMatchFailure("IsD128Enabled")
         }
     } else {
         d128enabled = false
@@ -28446,7 +28348,7 @@ function ProtectionEnabled el = {
           ? if ? == EL3 => {
               return(TCR_EL3[PnCH] == 0b1)
           },
-          _ => ()
+          _ => PatternMatchFailure("ProtectionEnabled")
         }
     } else {
         return(true)
@@ -28593,7 +28495,7 @@ function MemAtomicRCW (address, cmpoperand, operand, accdesc_in) = {
           newvalue = operand;
           cmpfail = oldvalue != cmpoperand
       },
-      _ => ()
+      _ => PatternMatchFailure("MemAtomicRCW")
     };
     if cmpfail then {
         nzcv = 0b1010
@@ -28908,7 +28810,7 @@ function AArch64_IsUnprivAccessPriv () = {
       ? if ? == EL3 => {
           privileged = true
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_IsUnprivAccessPriv")
     };
     if HaveUAOExt() & PSTATE.UAO == 0b1 then {
         privileged = PSTATE.EL != EL0
@@ -30043,7 +29945,7 @@ function FPTrigMAddCoefficient_read (index, N) = {
           15 => {
               result = UInt(0x0000)
           },
-          _ => ()
+          _ => PatternMatchFailure("FPTrigMAddCoefficient_read")
         }
     } else if N == 32 then {
         match index {
@@ -30095,7 +29997,7 @@ function FPTrigMAddCoefficient_read (index, N) = {
           15 => {
               result = UInt(0x00000000)
           },
-          _ => ()
+          _ => PatternMatchFailure("FPTrigMAddCoefficient_read")
         }
     } else {
         match index {
@@ -30147,7 +30049,7 @@ function FPTrigMAddCoefficient_read (index, N) = {
           15 => {
               result = UInt(0xbda8f76380fbb401)
           },
-          _ => ()
+          _ => PatternMatchFailure("FPTrigMAddCoefficient_read")
         }
     };
     let 'result = result;
@@ -30279,7 +30181,7 @@ function FPExpCoefficient_read (index, N) = {
           31 => {
               result = UInt(0x03d4)
           },
-          _ => ()
+          _ => PatternMatchFailure("FPExpCoefficient_read")
         }
     } else if N == 32 then {
         match index {
@@ -30475,7 +30377,7 @@ function FPExpCoefficient_read (index, N) = {
           63 => {
               result = UInt(0x7d3e0c)
           },
-          _ => ()
+          _ => PatternMatchFailure("FPExpCoefficient_read")
         }
     } else {
         match index {
@@ -30671,7 +30573,7 @@ function FPExpCoefficient_read (index, N) = {
           63 => {
               result = UInt(0xFA7C1819E90D8)
           },
-          _ => ()
+          _ => PatternMatchFailure("FPExpCoefficient_read")
         }
     };
     let 'result = result;
@@ -31304,7 +31206,7 @@ function CounterToPredicate (pred, width) = {
           count = UInt(pred[maxbit .. 4]);
           esize = 64
       },
-      _ => ()
+      _ => PatternMatchFailure("CounterToPredicate")
     };
     let 'esize = esize;
     let 'count = count;
@@ -31358,7 +31260,7 @@ function EncodePredCount (esize, elements, count_in, invert_in, width) = {
       64 => {
           pred = (inv @ count[10 .. 0]) @ 0b1000
       },
-      _ => ()
+      _ => PatternMatchFailure("EncodePredCount")
     };
     return(ZeroExtend(pred, width))
 }
@@ -31412,9 +31314,7 @@ function GCSReturnValueCheckEnabled el = {
       ? if ? == EL3 => {
           return(GCSCR_EL3[RVCHKEN] == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("GCSReturnValueCheckEnabled")
     }
 }
 
@@ -31435,7 +31335,7 @@ function GetCurrentGCSPointer () = {
       ? if ? == EL3 => {
           ptr = GCSPR_EL3[PTR] @ 0b000
       },
-      _ => ()
+      _ => PatternMatchFailure("GetCurrentGCSPointer")
     };
     return(ptr)
 }
@@ -31456,7 +31356,7 @@ function SetCurrentGCSPointer ptr = {
       ? if ? == EL3 => {
           GCSPR_EL3[PTR] = ptr[63 .. 3]
       },
-      _ => ()
+      _ => PatternMatchFailure("SetCurrentGCSPointer")
     };
     return()
 }
@@ -31822,7 +31722,7 @@ function CheckGCSSTREnabled () = {
           };
           ()
       },
-      _ => ()
+      _ => PatternMatchFailure("CheckGCSSTREnabled")
     };
     return()
 }
@@ -33101,7 +33001,7 @@ function AArch64_PhysicalSErrorTarget () = {
       ? if ? == EL0 => {
           masked = (not_bool(route_to_el3) & not_bool(route_to_el2)) & PSTATE.A == 0b1
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_PhysicalSErrorTarget")
     };
     if HaveDoubleFault2Ext() then {
         nmea_bit : bits(1) = undefined;
@@ -33124,7 +33024,7 @@ function AArch64_PhysicalSErrorTarget () = {
                     0b0
               }
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch64_PhysicalSErrorTarget")
         };
         masked = masked & nmea_bit == 0b0
     } else if HaveDoubleFaultExt() & PSTATE.EL == EL3 then {
@@ -33232,7 +33132,7 @@ function ExternalDebugInterruptsDisabled target = {
                   int_dis = EDSCR_read()[INTdis] != 0b00 & ExternalInvasiveDebugEnabled()
               }
           },
-          _ => ()
+          _ => PatternMatchFailure("ExternalDebugInterruptsDisabled")
         }
     };
     return(int_dis)
@@ -33397,7 +33297,7 @@ function TakeTransactionCheckpoint (vl, pl) = {
           ? if ? == EL3 => {
               TSTATE.GCSPR_ELx = GCSPR_EL3.bits
           },
-          _ => ()
+          _ => PatternMatchFailure("TakeTransactionCheckpoint")
         }
     };
     return()
@@ -35539,7 +35439,7 @@ function BRBEExceptionReturn (target_address_in, source_el) = {
           };
           ()
       },
-      _ => ()
+      _ => PatternMatchFailure("BRBEExceptionReturn")
     };
     let source_valid : bool = BranchRecordAllowed(source_el);
     let target_valid : bool = BranchRecordAllowed(PSTATE.EL);
@@ -35728,9 +35628,6 @@ function DecodeRegExtend op = {
       },
       0b111 => {
           return(ExtendType_SXTX)
-      },
-      _ => {
-          return(undefined : ExtendType)
       }
     }
 }
@@ -35799,9 +35696,6 @@ function DecodeShift op = {
       },
       0b11 => {
           return(ShiftType_ROR)
-      },
-      _ => {
-          return(undefined : ShiftType)
       }
     }
 }
@@ -36533,7 +36427,7 @@ function AArch64_TLBI_RPA (level, Xt, shareability) = {
       0b01 => {
           BaseADDR[51 .. 16] = Xt[39 .. 4]
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch64_TLBI_RPA")
     };
     assert(constraint('range_bits >= 0));
     assert(constraint(52 >= 'range_bits));
@@ -37251,7 +37145,7 @@ function AArch32_GetS1TTWParams (regime, va) = {
       Regime_EL30 => {
           walkparams = AArch32_S1TTWParamsEL30(va)
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch32_GetS1TTWParams")
     };
     return(walkparams)
 }
@@ -37270,9 +37164,7 @@ function AArch32_S1DCacheEnabled regime = {
           return((if HaveAArch32EL(EL3) then SCTLR_NS_read()[C] else
             SCTLR_read__2()[C]) == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("AArch32_S1DCacheEnabled")
     }
 }
 
@@ -37305,9 +37197,7 @@ function AArch32_S1ICacheEnabled regime = {
           return((if HaveAArch32EL(EL3) then SCTLR_NS_read()[I] else
             SCTLR_read__2()[I]) == 0b1)
       },
-      _ => {
-          return(undefined : bool)
-      }
+      _ => PatternMatchFailure("AArch32_S1ICacheEnabled")
     }
 }
 
@@ -37375,7 +37265,7 @@ function AArch32_S1DisabledOutput (fault_in, regime, va, aligned, accdesc) = {
               ntlsmd = if HaveAArch32EL(EL3) then SCTLR_NS_read()[nTLSMD] else
                 SCTLR_read__2()[nTLSMD]
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch32_S1DisabledOutput")
         }
     } else {
         ntlsmd = 0b1
@@ -37618,7 +37508,7 @@ function AArch32_GetS1TLBContext (regime, ss, va) = {
       Regime_EL30 => {
           tlbcontext = AArch32_TLBContextEL30(va)
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch32_GetS1TLBContext")
     };
     tlbcontext.includes_s1_name = true;
     tlbcontext.includes_s2_name = false;
@@ -38393,7 +38283,7 @@ function AArch32_S1SDHasPermissionsFault (regime, perms_in, memtype, paspace, ac
           0b111 => {
               (pr, pw, ur, uw) = (0b1, 0b0, 0b1, 0b0)
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch32_S1SDHasPermissionsFault")
         }
     } else {
         match perms.ap[2 .. 1] {
@@ -38409,7 +38299,7 @@ function AArch32_S1SDHasPermissionsFault (regime, perms_in, memtype, paspace, ac
           0b11 => {
               (pr, pw, ur, uw) = (0b1, 0b0, 0b1, 0b0)
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch32_S1SDHasPermissionsFault")
         }
     };
     let ux : bits(1) = ur & not_vec(perms.xn | uw & sctlr[WXN]);
@@ -38623,7 +38513,7 @@ function AArch32_RemappedTEXDecode (regime, TEX, C, B, s) = {
       0b11 => {
           Unreachable()
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch32_RemappedTEXDecode")
     };
     memattrs.inner.transient = false;
     memattrs.outer.transient = false;
@@ -38653,7 +38543,7 @@ function AArch32_TranslationSizeSD sdftype = {
       SDFType_Supersection => {
           tsize = 24
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch32_TranslationSizeSD")
     };
     let 'tsize = tsize;
     return(tsize)
@@ -38927,7 +38817,7 @@ function AArch32_SDStageOA (baseaddress, va, sdftype) = {
       SDFType_Supersection => {
           tsize = 24
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch32_SDStageOA")
     };
     let 'tsize = tsize;
     oa : FullAddress = undefined;
@@ -38964,7 +38854,7 @@ function AArch32_S1TranslateSD (fault_in, regime, va, aligned, accdesc) = {
               ntlsmd = if HaveAArch32EL(EL3) then SCTLR_NS_read()[nTLSMD] else
                 SCTLR_read__2()[nTLSMD]
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch32_S1TranslateSD")
         }
     } else {
         ntlsmd = 0b1
@@ -39040,7 +38930,7 @@ function AArch64_isPARFormatD128 (regime, is_ATS1Ex) = {
                   isPARFormatD128 = VTCR_EL2[D128] == 0b1
               }
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch64_isPARFormatD128")
         }
     };
     return(isPARFormatD128)
@@ -39477,7 +39367,7 @@ function DCPSInstruction target_el = {
               };
               ()
           },
-          _ => ()
+          _ => PatternMatchFailure("DCPSInstruction")
         };
         if handle_el == EL2 then {
             ELR_hyp_write() = __UNKNOWN_bits(32);
@@ -40322,7 +40212,7 @@ function AArch32_StateMatch (ssc_in, hmc_in, pxc_in, linked_in, linked_n_in, isb
           ? if ? == EL0 => {
               priv_match = pl0_match
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch32_StateMatch")
         }
     };
     ss_match : bool = undefined;
@@ -40339,7 +40229,7 @@ function AArch32_StateMatch (ssc_in, hmc_in, pxc_in, linked_in, linked_n_in, isb
       0b11 => {
           ss_match = hmc == 0b1 | accdesc.ss == SS_Secure
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch32_StateMatch")
     };
     linked_match : bool = false;
     if linked then {
@@ -40356,7 +40246,7 @@ function AArch32_StateMatch (ssc_in, hmc_in, pxc_in, linked_in, linked_n_in, isb
               Constraint_NONE => {
                   linked = false
               },
-              _ => ()
+              _ => PatternMatchFailure("AArch32_StateMatch")
             }
         };
         let 'linked_n = linked_n;
@@ -40631,7 +40521,7 @@ function AArch32_WatchpointByteMatch (n, vaddress) = {
           Constraint_NONE => {
               mask = 0
           },
-          _ => ()
+          _ => PatternMatchFailure("AArch32_WatchpointByteMatch")
         }
     };
     let 'mask = mask;
@@ -40674,7 +40564,7 @@ function AArch32_WatchpointMatch (n, vaddress, size, accdesc) = {
       0b11 => {
           ls_match = true
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch32_WatchpointMatch")
     };
     value_match_name : bool = false;
     foreach (byte from 0 to (size - 1) by 1 in inc) {
@@ -42267,7 +42157,7 @@ function ALUExceptionReturn address = {
           Constraint_NOP => {
               EndOfInstruction()
           },
-          _ => ()
+          _ => PatternMatchFailure("ALUExceptionReturn")
         }
     } else {
         AArch32_ExceptionReturn(address, SPSR_read(32))
@@ -43001,7 +42891,7 @@ function AArch32_CheckForWFxTrap (target_el, wfxtype) = {
       ? if ? == EL3 => {
           trap = (if is_wfe then SCR[TWE] else SCR[TWI]) == 0b1
       },
-      _ => ()
+      _ => PatternMatchFailure("AArch32_CheckForWFxTrap")
     };
     if trap then {
         if ((target_el == EL1 & EL2Enabled()) & not_bool(ELUsingAArch32(EL2))) & HCR_EL2[TGE] == 0b1 then {
@@ -43019,7 +42909,7 @@ function AArch32_CheckForWFxTrap (target_el, wfxtype) = {
               WFxType_WFE => {
                   except.syndrome[0] = Bit(0b1)
               },
-              _ => ()
+              _ => PatternMatchFailure("AArch32_CheckForWFxTrap")
             };
             AArch32_TakeHypTrapException__1(except)
         } else {


### PR DESCRIPTION
Raise an error in case of a pattern match failure rather than allowing undefined behaviour.  This better reflects the intended ASL semantics.

Also remove a number of unnecessary fall-through cases that were introduced due to bugs in asl_to_sail, as reported in issue #16.