### PR TITLE
arm-v9.4-a: support Lean backend generation

### DIFF
--- a/arm-v9.4-a/Makefile
+++ b/arm-v9.4-a/Makefile
@@ -63,6 +63,13 @@ gen_coq coq coq.stamp: $(SAIL_SRCS) src/coq_termination.sail
 	        src/coq_termination.sail
 	touch coq.stamp
 
+gen_lean lean lean.stamp: $(SAIL_SRCS)
+	$(SAIL) -dprofile -verbose 1 -memo_z3 \
+			-lean -lean_output_dir lean -o armv9 \
+			-undefined_gen \
+			$(SAIL_SRCS) $(SAIL_FLAGS)
+	touch lean.stamp
+
 c/armv9.c: $(SAIL_SRCS) $(SAIL_MAIN)
 	mkdir -p c
 	$(SAIL) -dprofile -verbose 1 -memo_z3 \


### PR DESCRIPTION
Follow the same code that the Coq generation uses.

This fails at the following step:
```
Type error:
src/v8_base.sail:25089.8-15:
25089 |    let 'max_ps = max_ps;
      |        ^-----^
      | No type variable 'max_ps
make: *** [Makefile:67: gen_lean] Error 1
```