### PR TITLE
Enable real numbers in the Sail backend for Lean

### DIFF
--- a/arm-v9.4-a/Makefile
+++ b/arm-v9.4-a/Makefile
@@ -85,6 +85,7 @@ gen_lean lean lean.stamp: $(SAIL_SRCS) src/termination_measures.sail
 	        -lean_output_dir lean -o armv9 \
 	        -undefined_gen \
 	        -lean-noncomputable \
+	        -lean-real-numbers \
 	        $(SAIL_SRCS) $(SAIL_FLAGS) \
 	        src/termination_measures.sail
 


### PR DESCRIPTION
By default the Lean backend does not handle real numbers, so we need to enable it using a command line flag.