### PR TITLE
Improve Lean support

### DIFF
--- a/arm-v9.4-a/Makefile
+++ b/arm-v9.4-a/Makefile
@@ -1,6 +1,8 @@
 LEM=lem
 CC=gcc
 
+VERBOSE_FLAG = -verbose 1
+
 # Attempt to work with either sail from opam or built from repo in SAIL_DIR
 ifneq ($(SAIL_DIR),)
 # Use sail repo in SAIL_DIR
@@ -36,13 +38,13 @@ LEM_INSTRS_FILES=instrs32.lem instrs64.lem
 LEM_VECTOR_INSTRS_FILES=instrs64_sme.lem instrs64_sve.lem
 LEM_LIBS=-lib Sail=$(SAIL_DIR)/src/gen_lib -lib Sail-Armv9-Base=lem/base -lib Sail-Armv9-System=lem/system -lib Sail-Armv9-Instrs=lem/instrs -lib Sail-Armv9-Vector-Instrs=lem/vector_instrs
 
-all: lem.stamp isabelle.stamp coq.stamp
+all: lem.stamp isabelle.stamp coq.stamp lean.stamp
 
 .PHONY: all clean interactive gen_c gen_isabelle
 
 lem lem.stamp: $(SAIL_SRCS) $(LEM_SPLICES) lem/base/extra_defs.lem src/termination_measures.sail src/lem-patches/Feature.patch
 	mkdir -p isabelle
-	$(SAIL) -dprofile -verbose 1 -memo_z3 -grouped_regstate -lem_split_files \
+	$(SAIL) -dprofile $(VERBOSE_FLAG) -memo_z3 -grouped_regstate -lem_split_files \
 	        -lem -lem_output_dir lem -isa_output_dir isabelle -o armv9 -lem_lib Extra_defs \
 	        -lem_mwords -mono_rewrites -auto_mono -undefined_gen \
 	        $(foreach splice,$(LEM_SPLICES),-splice $(splice)) \
@@ -71,7 +73,7 @@ gen_isabelle isabelle isabelle.stamp: lem.stamp
 	touch isabelle.stamp
 
 gen_coq coq coq.stamp: $(SAIL_SRCS) src/termination_measures.sail
-	$(SAIL) -dprofile -verbose 1 -memo_z3 \
+	$(SAIL) -dprofile $(VERBOSE_FLAG) -memo_z3 \
 	        -coq -dcoq_undef_axioms \
 	        -coq_output_dir coq -o armv9 -coq_lib arm_extras \
 	        -undefined_gen \
@@ -79,18 +81,23 @@ gen_coq coq coq.stamp: $(SAIL_SRCS) src/termination_measures.sail
 	        src/termination_measures.sail
 	touch coq.stamp
 
-gen_lean lean lean.stamp: $(SAIL_SRCS) src/termination_measures.sail
-	$(SAIL) -dprofile -verbose 1 -memo_z3 \
+gen_lean lean lean.stamp: $(SAIL_SRCS) src/termination_measures.sail lean/ArmExtras.lean
+	$(SAIL) -dprofile $(VERBOSE_FLAG) -memo_z3 \
 	        -lean --lean-force-output \
 	        -lean_output_dir lean -o armv9 \
 	        -undefined_gen \
+	        -memo-z3 \
 	        -lean-noncomputable \
+	        -lean-line-width 100000 \
+	        -lean-force-output \
+	        -lean-import-file lean/ArmExtras.lean \
 	        $(SAIL_SRCS) $(SAIL_FLAGS) \
 	        src/termination_measures.sail
+	touch lean.stamp
 
 c/armv9.c: $(SAIL_SRCS) $(SAIL_MAIN)
 	mkdir -p c
-	$(SAIL) -dprofile -verbose 1 -memo_z3 \
+	$(SAIL) -dprofile $(VERBOSE_FLAG) -memo_z3 \
 		-c $(SAIL_C_FLAGS) $(SAIL_FLAGS) $(SAIL_SRCS) $(SAIL_MAIN) > c/armv9.c.temp
 	mv c/armv9.c.temp c/armv9.c
 
@@ -111,7 +118,7 @@ interface_types.sail: $(SAIL_SRCS)
 	rm interface_types.sail.in
 
 interactive:
-	$(SAIL) -i -memo_z3 -verbose 1 \
+	$(SAIL) -i -memo_z3 $(VERBOSE_FLAG) \
 	        $(SAIL_SRCS) $(SAIL_FLAGS) \
 	        src/termination_measures.sail
 
@@ -120,5 +127,6 @@ clean:
 	rm -f isabelle.stamp isabelle/Arm_lemmas.thy isabelle/Arm.thy isabelle/Arm_types.thy \
 	  isabelle/Prelude.thy isabelle/ArmAuxiliary.thy
 	rm -f coq.stamp coq/{arm_extras,armv9,armv9_types}.{v,vo,vok,vos,glob}
+	rm -rf lean.stamp lean/armv9
 	rm -f ir/armv9.ir
 	rm -f interface_types.sail

--- a/arm-v9.4-a/lean/ArmExtras.lean
+++ b/arm-v9.4-a/lean/ArmExtras.lean
@@ -1,0 +1,22 @@
+
+import THE_MODULE_NAME.Sail.Sail
+import THE_MODULE_NAME.Defs
+import THE_MODULE_NAME.Specialization
+
+open Sail
+
+abbrev sign_extend {w : Nat} (x : BitVec w) (w' : Nat) := Sail.BitVec.signExtend x w'
+
+def dec_str (x : Int) := x.repr
+def hex_str (x : Int) := x.toHex
+
+def putchar (_ : Int) : Unit := ()
+
+def sleep_request (_ : Unit) : SailM Unit := pure ()
+def wakeup_request (_ : Unit) : SailM Unit := pure ()
+
+macro_rules | `(tactic| decreasing_trivial) => `(tactic|
+  first
+  | grind
+  | decide
+  | sorry)

--- a/arm-v9.4-a/src/prelude.sail
+++ b/arm-v9.4-a/src/prelude.sail
@@ -98,7 +98,8 @@ val ediv_nat = pure {
   interpreter: "quotient",
   lem: "integerDiv",
   c: "ediv_int",
-  coq: "ZEuclid.div"
+  coq: "ZEuclid.div",
+  lean: "Int.ediv"
 } : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(div('n, 'm))
 
 val emod_nat = pure {
@@ -106,7 +107,8 @@ val emod_nat = pure {
   interpreter: "modulus",
   lem: "integerMod",
   c: "emod_int",
-  coq: "ZEuclid.modulo"
+  coq: "ZEuclid.modulo",
+  lean: "Nat.div"
 } : forall 'n 'm, 'n >= 0 & 'm > 0. (int('n), int('m)) -> int(mod('n, 'm))
 
 overload DIV = {ediv_nat, fdiv_int}
@@ -125,7 +127,8 @@ val UInt0 = pure {
   lem: "uint",
   interpreter: "uint",
   c: "sail_unsigned",
-  coq: "uint"
+  coq: "uint",
+  lean: "BitVec.toNat",
 } : forall 'n. bits('n) -> {'m, 0 <= 'm < 2 ^ 'n. int('m)}
 
 val UInt1 = pure { coq: "uint" } : forall 'n. (int('n), bits('n)) -> {'m, 0 <= 'm < 2 ^ 'n. int('m)}
@@ -135,6 +138,7 @@ overload UInt = {UInt0, UInt1}
 
 val SInt0 = pure {
   c: "sail_signed",
+  lean: "BitVec.toInt",
   _: "sint"
 } : forall 'n, 'n > 0. bits('n) -> {'m, - (2 ^ ('n - 1)) <= 'm < 2 ^ ('n - 1). int('m)}
 
@@ -186,7 +190,8 @@ val array_access = pure {
   interpreter: "access",
   lem: "access_list_inc",
   coq: "vec_access_inc",
-  c: "vector_access"
+  lean: "GetElem?.getElem!",
+  c: "vector_access",
 } : forall ('n : Int) ('m : Int) ('a : Type), 0 <= 'm < 'n. (vector('n, inc, 'a), int('m)) -> 'a
 
 overload vector_access = {array_access}
@@ -196,12 +201,13 @@ val array_update = pure {
   interpreter: "update",
   lem: "update_list_inc",
   coq: "vec_update_inc",
+  lean: "BitVec.update",
   c: "vector_update"
 } : forall 'n 'm ('a : Type), 0 <= 'm < 'n. (vector('n, inc, 'a), int('m), 'a) -> vector('n, inc, 'a)
 
 overload vector_update = {array_update}
 
-val sub_bits_int = pure {c:"sub_bits_int", _: "sub_vec_int"} : forall 'n, 'n > 0. (bits('n), int) -> bits('n)
+val sub_bits_int = pure {c:"sub_bits_int", lean: "BitVec.subInt", _: "sub_vec_int"} : forall 'n, 'n > 0. (bits('n), int) -> bits('n)
 
 overload operator - = {sub_bits, sub_bits_int}
 
@@ -218,7 +224,7 @@ function SignExtend1(m, x) = SignExtend0(x, m)
 
 overload SignExtend = {SignExtend0, SignExtend1}
 
-val ZeroExtend0 = pure "zero_extend" : forall 'n 'm, 'n >= 0 & 'm >= 'n.
+val ZeroExtend0 = pure { lean: "Sail.BitVec.zeroExtend", _: "zero_extend" } : forall 'n 'm, 'n >= 0 & 'm >= 'n.
   (bits('n), int('m)) -> bits('m)
 
 val ZeroExtend1 : forall 'n 'm, 'n >= 0 & 'm >= 'n.
@@ -293,7 +299,7 @@ val HexStr = pure "hex_str" : int -> string
 val BoolStr : bool -> string
 function BoolStr b = match b { true => "true", false => "false" }
 
-val append_str = pure {ocaml: "concat_str", interpreter: "concat_str", lem: "stringAppend", c: "concat_str", coq: "String.append" } :
+val append_str = pure {ocaml: "concat_str", interpreter: "concat_str", lem: "stringAppend", c: "concat_str", coq: "String.append", lean: "String.append" } :
   (string, string) -> string
 
 function append_int(str: string, n: int) -> string = {
@@ -321,7 +327,8 @@ val putchar = pure {
   lem: "putchar",
   interpreter: "putchar",
   c: "sail_putchar",
-  coq: "putchar"
+  coq: "putchar",
+  lean: "putchar"
 } : int -> unit
 
 val __IMPDEF_boolean : string -> bool
@@ -352,17 +359,17 @@ val PL_of_VL : forall 'vl, 'vl >= 0. int('vl) -> int(div('vl, 8))
 
 function PL_of_VL(vl) = DIV(vl, 8)
 
-val __SleepRequest = monadic {ocaml: "sleep_request", lem: "sleep_request", smt: "sleep_request", interpreter: "sleep_request", c: "sleep_request"}: unit -> unit
+val __SleepRequest = monadic {ocaml: "sleep_request", lem: "sleep_request", smt: "sleep_request", interpreter: "sleep_request", c: "sleep_request", lean: "sleep_request"}: unit -> unit
 
-val __WakeupRequest = monadic {ocaml: "wakeup_request", lem: "wakeup_request", smt: "wakeup_request", interpreter: "wakeup_request", c: "wakeup_request"}: unit -> unit
+val __WakeupRequest = monadic {ocaml: "wakeup_request", lem: "wakeup_request", smt: "wakeup_request", interpreter: "wakeup_request", c: "wakeup_request", lean: "wakeup_request"}: unit -> unit
 
 /* C emulator support functions */
 
 val __GetVerbosity = monadic {c: "sail_get_verbosity"} : unit -> bits(64)
 function __GetVerbosity() = 0x0000_0000_0000_0000
 
-val check_cycle_count = monadic { c: "cycle_count" } : unit -> unit
+val check_cycle_count = monadic { c: "cycle_count", lean: "cycle_count" } : unit -> unit
 function check_cycle_count() = ()
 
-val get_cycle_count = monadic { c: "get_cycle_count" } : unit -> int
+val get_cycle_count = monadic { c: "get_cycle_count", lean: "get_cycle_count" } : unit -> int
 function get_cycle_count() = 0

--- a/arm-v9.4-a/src/termination_measures.sail
+++ b/arm-v9.4-a/src/termination_measures.sail
@@ -40,6 +40,8 @@
 
 termination_measure Reduce__1(op,input,esize,altfp) = 'N
 
+$iftarget coq
+
 termination_measure BranchEncCycleCount
   while cc
 
@@ -110,3 +112,5 @@ termination_measure AArch32_S1WalkSD repeat 100
 termination_measure decode_max_smeveclen while svl
 
 termination_measure SPEConstructRecord while 64
+
+$endif


### PR DESCRIPTION
Adds more annotations to make the Lean model compile.

This also makes the verbosity level of sail configurable, so that it can be disabled in CI to make the output manageable.