### PR TITLE
Updated .gitignores to reflect the name change of z3_problems to sail_smt_cache in sail 0.20.1

### DIFF
--- a/arm-v9.3-a/.gitignore
+++ b/arm-v9.3-a/.gitignore
@@ -12,5 +12,6 @@
 /sail-arm-boot-master/
 /sail.dtb
 z3_problems
+sail_smt_cache
 /snapshots/c/armv9
 /snapshots/c/armv9.c

--- a/arm-v9.4-a/.gitignore
+++ b/arm-v9.4-a/.gitignore
@@ -21,5 +21,6 @@
 /sail-arm-boot-master/
 /sail.dtb
 z3_problems
+sail_smt_cache
 /snapshots/c/armv9
 /snapshots/c/armv9.c


### PR DESCRIPTION
Sail commit [b9b3411](https://github.com/rems-project/sail/commit/b9b3411cbb2e742479a9b9b56dc8a4bbd1c7c6b5), which was a part of Sail 0.20.1, changed the name of z3_problems to sail_smt_cache. I've added sail_smt_cache to the .gitignore files for arm-v9.4-a and arm-v9.3-a. I have kept z3_problems in the .gitignore files so that users of older sail versions will still have that artifact ignored. Happy to get rid of that if desired.

I'll note that the arm-v8.5-a model does not have a .gitignore, and I didn't bother to create one. I have no intentions of building the v8.5 model for my work, but please advise if you would prefer a .gitignore to be created for that model for this PR.

Thank you!